### PR TITLE
feat: desktop app with monorepo, shared package, and desktop features

### DIFF
--- a/desktop/src-tauri/src/commands/mod.rs
+++ b/desktop/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod auth;
 pub mod settings;
+pub mod tray;
 
 use std::sync::RwLock;
 

--- a/desktop/src-tauri/src/commands/settings.rs
+++ b/desktop/src-tauri/src/commands/settings.rs
@@ -43,6 +43,19 @@ fn get_settings_path(app: &AppHandle) -> Result<PathBuf, SettingsError> {
     Ok(app_dir.join("settings.json"))
 }
 
+/// Synchronous version for use in non-async contexts (e.g., window close handler)
+pub fn get_settings_sync(app: &AppHandle) -> Result<AppSettings, SettingsError> {
+    let path = get_settings_path(app)?;
+
+    if !path.exists() {
+        return Ok(AppSettings::default());
+    }
+
+    let contents = fs::read_to_string(&path).map_err(|e| SettingsError::IoError(e.to_string()))?;
+
+    serde_json::from_str(&contents).map_err(|e| SettingsError::SerializationError(e.to_string()))
+}
+
 #[tauri::command]
 pub async fn get_settings(app: AppHandle) -> Result<AppSettings, SettingsError> {
     let path = get_settings_path(&app)?;

--- a/desktop/src-tauri/src/commands/tray.rs
+++ b/desktop/src-tauri/src/commands/tray.rs
@@ -1,0 +1,83 @@
+use tauri::{
+    menu::{MenuBuilder, MenuItemBuilder},
+    tray::TrayIconBuilder,
+    AppHandle, Manager,
+};
+
+pub fn create_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
+    let show = MenuItemBuilder::with_id("show", "Show Relate Mail").build(app)?;
+    let quit = MenuItemBuilder::with_id("quit", "Quit").build(app)?;
+
+    let menu = MenuBuilder::new(app)
+        .item(&show)
+        .separator()
+        .item(&quit)
+        .build()?;
+
+    let _tray = TrayIconBuilder::with_id("main")
+        .menu(&menu)
+        .tooltip("Relate Mail")
+        .on_menu_event(move |app, event| match event.id().as_ref() {
+            "show" => {
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                    let _ = window.unminimize();
+                }
+            }
+            "quit" => {
+                app.exit(0);
+            }
+            _ => {}
+        })
+        .on_tray_icon_event(|tray, event| {
+            if let tauri::tray::TrayIconEvent::Click {
+                button: tauri::tray::MouseButton::Left,
+                button_state: tauri::tray::MouseButtonState::Up,
+                ..
+            } = event
+            {
+                let app = tray.app_handle();
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                    let _ = window.unminimize();
+                }
+            }
+        })
+        .build(app)?;
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn set_tray_tooltip(tooltip: String, app: AppHandle) -> Result<(), String> {
+    if let Some(tray) = app.tray_by_id("main") {
+        tray.set_tooltip(Some(&tooltip)).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn set_badge_count(count: u32, app: AppHandle) -> Result<(), String> {
+    if let Some(tray) = app.tray_by_id("main") {
+        let tooltip = if count > 0 {
+            format!("Relate Mail - {} unread", count)
+        } else {
+            "Relate Mail".to_string()
+        };
+        tray.set_tooltip(Some(&tooltip)).map_err(|e| e.to_string())?;
+    }
+
+    // Also update the window title to reflect unread count
+    if let Some(window) = app.get_webview_window("main") {
+        let title = if count > 0 {
+            format!("({}) Relate Mail", count)
+        } else {
+            "Relate Mail".to_string()
+        };
+        window.set_title(&title).map_err(|e| e.to_string())?;
+    }
+
+    Ok(())
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -10,6 +10,34 @@ pub fn run() {
         .setup(|app| {
             // Initialize app state
             app.manage(commands::AppState::default());
+
+            // Create system tray
+            if let Err(e) = commands::tray::create_tray(app.handle()) {
+                eprintln!("Failed to create tray: {}", e);
+            }
+
+            // Handle window close event - minimize to tray instead of quitting
+            let app_handle = app.handle().clone();
+            if let Some(window) = app.get_webview_window("main") {
+                window.on_window_event(move |event| {
+                    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                        // Check settings for minimize_to_tray preference
+                        let should_minimize = commands::settings::get_settings_sync(&app_handle)
+                            .map(|s| s.minimize_to_tray)
+                            .unwrap_or(false);
+
+                        if should_minimize {
+                            // Hide window instead of closing
+                            api.prevent_close();
+                            if let Some(win) = app_handle.get_webview_window("main") {
+                                let _ = win.hide();
+                            }
+                        }
+                        // If not minimize_to_tray, default behavior (close + quit)
+                    }
+                });
+            }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -23,6 +51,8 @@ pub fn run() {
             commands::auth::clear_credentials,
             commands::settings::get_settings,
             commands::settings::save_settings,
+            commands::tray::set_tray_tooltip,
+            commands::tray::set_badge_count,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -4,10 +4,13 @@ import { authAtom } from './stores/auth'
 import { Sidebar } from './components/desktop/Sidebar'
 import { Inbox } from './views/Inbox'
 import { Settings } from './views/Settings'
+import { SmtpSettings } from './views/SmtpSettings'
 import { Login } from './views/Login'
 import { useTheme } from './hooks/useTheme'
+import { usePolling } from './hooks/usePolling'
+import { useWindowState } from './hooks/useWindowState'
 
-type View = 'inbox' | 'sent' | 'settings'
+type View = 'inbox' | 'sent' | 'smtp-settings' | 'settings'
 
 function App() {
   const [auth] = useAtom(authAtom)
@@ -15,6 +18,12 @@ function App() {
 
   // Initialize theme (follows system by default)
   useTheme()
+
+  // Background polling for new emails (only when authenticated)
+  usePolling(auth.isAuthenticated)
+
+  // Persist window size and position
+  useWindowState()
 
   // Show login if not authenticated
   if (!auth.isAuthenticated) {
@@ -31,6 +40,7 @@ function App() {
             Sent emails coming soon
           </div>
         )}
+        {currentView === 'smtp-settings' && <SmtpSettings />}
         {currentView === 'settings' && <Settings />}
       </main>
     </div>

--- a/desktop/src/api/hooks.ts
+++ b/desktop/src/api/hooks.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiGet, apiPost, apiPatch, apiDelete } from './client'
-import type { EmailListResponse, EmailDetail, Profile } from '@relate/shared/api/types'
+import type { EmailListResponse, EmailDetail, Profile, SmtpCredentials, CreateApiKeyRequest, CreatedApiKey } from '@relate/shared/api/types'
 
 // Emails
 export function useEmails(page = 1, pageSize = 20) {
@@ -56,6 +56,38 @@ export interface EmailSearchFilters {
   toDate?: string
   hasAttachments?: boolean
   isRead?: boolean
+}
+
+// SMTP Credentials
+export function useSmtpCredentials() {
+  return useQuery({
+    queryKey: ['smtp-credentials'],
+    queryFn: () => apiGet<SmtpCredentials>('/smtp-credentials'),
+  })
+}
+
+export function useCreateSmtpApiKey() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: CreateApiKeyRequest) =>
+      apiPost<CreatedApiKey>('/smtp-credentials', data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['smtp-credentials'] })
+    },
+  })
+}
+
+export function useRevokeSmtpApiKey() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (keyId: string) =>
+      apiDelete(`/smtp-credentials/${keyId}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['smtp-credentials'] })
+    },
+  })
 }
 
 export function useSearchEmails(filters: EmailSearchFilters, page = 1) {

--- a/desktop/src/components/desktop/Sidebar.tsx
+++ b/desktop/src/components/desktop/Sidebar.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@relate/shared/components/ui'
-import { Inbox, Send, Settings, LogOut } from 'lucide-react'
+import { Inbox, Send, KeyRound, Settings, LogOut } from 'lucide-react'
 import { useSetAtom } from 'jotai'
 import { logoutAtom } from '@/stores/auth'
 
-type View = 'inbox' | 'sent' | 'settings'
+type View = 'inbox' | 'sent' | 'smtp-settings' | 'settings'
 
 interface SidebarProps {
   currentView: View
@@ -40,14 +40,22 @@ export function Sidebar({ currentView, onNavigate }: SidebarProps) {
         </div>
       </nav>
 
-      <div className="p-2 border-t">
+      <div className="p-2 border-t space-y-1">
+        <Button
+          variant={currentView === 'smtp-settings' ? 'secondary' : 'ghost'}
+          className="w-full justify-start"
+          onClick={() => onNavigate('smtp-settings')}
+        >
+          <KeyRound className="h-4 w-4 mr-2" />
+          SMTP Settings
+        </Button>
         <Button
           variant={currentView === 'settings' ? 'secondary' : 'ghost'}
           className="w-full justify-start"
           onClick={() => onNavigate('settings')}
         >
           <Settings className="h-4 w-4 mr-2" />
-          Settings
+          Preferences
         </Button>
         <Button
           variant="ghost"

--- a/desktop/src/hooks/usePolling.ts
+++ b/desktop/src/hooks/usePolling.ts
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { invoke } from '@tauri-apps/api/core'
+import { isPermissionGranted, requestPermission, sendNotification } from '@tauri-apps/plugin-notification'
+import { apiGet } from '../api/client'
+import type { EmailListResponse } from '@relate/shared/api/types'
+
+const POLL_INTERVAL = 60_000 // 1 minute
+
+export function usePolling(enabled = true) {
+  const queryClient = useQueryClient()
+  const previousUnreadRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!enabled) return
+
+    let active = true
+
+    async function poll() {
+      if (!active) return
+
+      try {
+        const data = await apiGet<EmailListResponse>('/emails?page=1&pageSize=1')
+        const unreadCount = data.unreadCount
+
+        // Update badge
+        await invoke('set_badge_count', { count: unreadCount }).catch(() => {})
+
+        // Send notification if new unread emails arrived (check setting)
+        if (
+          previousUnreadRef.current !== null &&
+          unreadCount > previousUnreadRef.current
+        ) {
+          const newCount = unreadCount - previousUnreadRef.current
+          try {
+            const settings = await invoke<{ show_notifications: boolean }>('get_settings')
+            if (settings.show_notifications) {
+              await notifyNewEmails(newCount)
+            }
+          } catch {
+            await notifyNewEmails(newCount)
+          }
+        }
+
+        previousUnreadRef.current = unreadCount
+
+        // Invalidate email queries so UI refreshes
+        queryClient.invalidateQueries({ queryKey: ['emails'] })
+      } catch {
+        // Silently ignore polling errors
+      }
+    }
+
+    const interval = setInterval(poll, POLL_INTERVAL)
+
+    // Initial poll
+    poll()
+
+    return () => {
+      active = false
+      clearInterval(interval)
+    }
+  }, [queryClient, enabled])
+}
+
+async function notifyNewEmails(count: number) {
+  try {
+    let permitted = await isPermissionGranted()
+    if (!permitted) {
+      const permission = await requestPermission()
+      permitted = permission === 'granted'
+    }
+
+    if (permitted) {
+      sendNotification({
+        title: 'Relate Mail',
+        body: count === 1
+          ? 'You have 1 new email'
+          : `You have ${count} new emails`,
+      })
+    }
+  } catch {
+    // Notifications not available
+  }
+}

--- a/desktop/src/hooks/useWindowState.ts
+++ b/desktop/src/hooks/useWindowState.ts
@@ -1,0 +1,81 @@
+import { useEffect } from 'react'
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import { invoke } from '@tauri-apps/api/core'
+
+interface AppSettings {
+  theme: string
+  minimize_to_tray: boolean
+  show_notifications: boolean
+  window_width: number | null
+  window_height: number | null
+  window_x: number | null
+  window_y: number | null
+}
+
+export function useWindowState() {
+  useEffect(() => {
+    const window = getCurrentWindow()
+
+    // Restore saved window state on mount
+    async function restore() {
+      try {
+        const settings: AppSettings = await invoke('get_settings')
+        if (settings.window_width && settings.window_height) {
+          await window.setSize({
+            type: 'Logical',
+            width: settings.window_width,
+            height: settings.window_height,
+          })
+        }
+        if (settings.window_x !== null && settings.window_y !== null) {
+          await window.setPosition({
+            type: 'Logical',
+            x: settings.window_x,
+            y: settings.window_y,
+          })
+        }
+      } catch {
+        // Use default window state
+      }
+    }
+
+    restore()
+
+    // Save window state periodically and on close
+    let saveTimeout: ReturnType<typeof setTimeout> | null = null
+
+    async function saveState() {
+      try {
+        const size = await window.innerSize()
+        const position = await window.outerPosition()
+        const settings: AppSettings = await invoke('get_settings')
+
+        await invoke('save_settings', {
+          settings: {
+            ...settings,
+            window_width: size.width,
+            window_height: size.height,
+            window_x: position.x,
+            window_y: position.y,
+          },
+        })
+      } catch {
+        // Ignore save errors
+      }
+    }
+
+    function debouncedSave() {
+      if (saveTimeout) clearTimeout(saveTimeout)
+      saveTimeout = setTimeout(saveState, 500)
+    }
+
+    const unlistenMove = window.onMoved(debouncedSave)
+    const unlistenResize = window.onResized(debouncedSave)
+
+    return () => {
+      if (saveTimeout) clearTimeout(saveTimeout)
+      unlistenMove.then(fn => fn())
+      unlistenResize.then(fn => fn())
+    }
+  }, [])
+}

--- a/desktop/src/views/Settings.tsx
+++ b/desktop/src/views/Settings.tsx
@@ -1,17 +1,124 @@
+import { useState, useEffect } from 'react'
 import { useAtom } from 'jotai'
+import { invoke } from '@tauri-apps/api/core'
 import { authAtom } from '@/stores/auth'
 import { useProfile } from '@/api/hooks'
-import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@relate/shared/components/ui'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, Switch } from '@relate/shared/components/ui'
+
+interface AppSettings {
+  theme: string
+  minimize_to_tray: boolean
+  show_notifications: boolean
+  window_width: number | null
+  window_height: number | null
+  window_x: number | null
+  window_y: number | null
+}
+
+const defaultSettings: AppSettings = {
+  theme: 'system',
+  minimize_to_tray: false,
+  show_notifications: true,
+  window_width: null,
+  window_height: null,
+  window_x: null,
+  window_y: null,
+}
 
 export function Settings() {
   const [auth] = useAtom(authAtom)
   const { data: profile, isLoading } = useProfile()
+  const [settings, setSettings] = useState<AppSettings>(defaultSettings)
+
+  useEffect(() => {
+    invoke<AppSettings>('get_settings').then(setSettings).catch(() => {})
+  }, [])
+
+  async function updateSetting<K extends keyof AppSettings>(key: K, value: AppSettings[K]) {
+    const updated = { ...settings, [key]: value }
+    setSettings(updated)
+    try {
+      await invoke('save_settings', { settings: updated })
+
+      // Apply theme change immediately
+      if (key === 'theme') {
+        applyTheme(value as string)
+      }
+    } catch {
+      // Revert on error
+      setSettings(settings)
+    }
+  }
 
   return (
-    <div className="p-6 max-w-2xl mx-auto">
-      <h1 className="text-2xl font-bold mb-6">Settings</h1>
+    <div className="h-full overflow-auto p-6 max-w-2xl">
+      <h1 className="text-2xl font-bold mb-6">Preferences</h1>
 
       <div className="space-y-6">
+        {/* Appearance */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Appearance</CardTitle>
+            <CardDescription>Customize how the app looks</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <label className="text-sm font-medium mb-2 block">Theme</label>
+              <div className="flex gap-2">
+                {(['system', 'light', 'dark'] as const).map((theme) => (
+                  <button
+                    key={theme}
+                    onClick={() => updateSetting('theme', theme)}
+                    className={`px-4 py-2 rounded border text-sm capitalize ${
+                      settings.theme === theme
+                        ? 'bg-primary text-primary-foreground border-primary'
+                        : 'bg-card border-border hover:bg-accent'
+                    }`}
+                  >
+                    {theme}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Behavior */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Behavior</CardTitle>
+            <CardDescription>Control how the app behaves</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium">Minimize to tray</p>
+                <p className="text-sm text-muted-foreground">
+                  Keep the app running in the system tray when you close the window
+                </p>
+              </div>
+              <Switch
+                checked={settings.minimize_to_tray}
+                onCheckedChange={(checked) => updateSetting('minimize_to_tray', checked)}
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium">Desktop notifications</p>
+                <p className="text-sm text-muted-foreground">
+                  Show notifications when new emails arrive
+                </p>
+              </div>
+              <Switch
+                checked={settings.show_notifications}
+                onCheckedChange={(checked) => updateSetting('show_notifications', checked)}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Account */}
         <Card>
           <CardHeader>
             <CardTitle>Account</CardTitle>
@@ -41,6 +148,7 @@ export function Settings() {
           </CardContent>
         </Card>
 
+        {/* About */}
         <Card>
           <CardHeader>
             <CardTitle>About</CardTitle>
@@ -60,4 +168,20 @@ export function Settings() {
       </div>
     </div>
   )
+}
+
+function applyTheme(theme: string) {
+  const root = document.documentElement
+  if (theme === 'dark') {
+    root.classList.add('dark')
+  } else if (theme === 'light') {
+    root.classList.remove('dark')
+  } else {
+    // System
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+  }
 }

--- a/desktop/src/views/SmtpSettings.tsx
+++ b/desktop/src/views/SmtpSettings.tsx
@@ -1,0 +1,344 @@
+import { useState } from 'react'
+import { useSmtpCredentials, useCreateSmtpApiKey, useRevokeSmtpApiKey } from '../api/hooks'
+import { Button } from '@relate/shared/components/ui'
+import { Input } from '@relate/shared/components/ui'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@relate/shared/components/ui'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogFooter } from '@relate/shared/components/ui'
+import { Trash2, Plus, Copy, Check, KeyRound } from 'lucide-react'
+import { formatDistanceToNow } from 'date-fns'
+
+export function SmtpSettings() {
+  const { data: credentials, isLoading } = useSmtpCredentials()
+  const createKey = useCreateSmtpApiKey()
+  const revokeKey = useRevokeSmtpApiKey()
+
+  const [isCreatingKey, setIsCreatingKey] = useState(false)
+  const [keyName, setKeyName] = useState('')
+  const [selectedScopes, setSelectedScopes] = useState<string[]>(['smtp', 'pop3', 'imap', 'api:read', 'api:write'])
+  const [createdKey, setCreatedKey] = useState<{ apiKey: string; name: string; scopes: string[] } | null>(null)
+  const [copiedKey, setCopiedKey] = useState(false)
+
+  const scopeOptions = [
+    { value: 'smtp', label: 'SMTP', description: 'Send emails via SMTP server' },
+    { value: 'pop3', label: 'POP3', description: 'Retrieve emails via POP3 server' },
+    { value: 'imap', label: 'IMAP', description: 'Retrieve emails via IMAP server' },
+    { value: 'api:read', label: 'API Read', description: 'Read emails via REST API' },
+    { value: 'api:write', label: 'API Write', description: 'Modify/delete emails via REST API' },
+  ]
+
+  const handleCreateKey = () => {
+    if (keyName.trim() && selectedScopes.length > 0) {
+      createKey.mutate({ name: keyName.trim(), scopes: selectedScopes }, {
+        onSuccess: (data) => {
+          setCreatedKey({ apiKey: data.apiKey, name: data.name, scopes: data.scopes })
+          setKeyName('')
+          setSelectedScopes(['smtp', 'pop3', 'imap', 'api:read', 'api:write'])
+          setIsCreatingKey(false)
+        },
+      })
+    }
+  }
+
+  const handleCopyKey = async () => {
+    if (createdKey) {
+      await navigator.clipboard.writeText(createdKey.apiKey)
+      setCopiedKey(true)
+      setTimeout(() => setCopiedKey(false), 2000)
+    }
+  }
+
+  const handleCloseKeyModal = () => {
+    setCreatedKey(null)
+    setCopiedKey(false)
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full text-muted-foreground">
+        Loading...
+      </div>
+    )
+  }
+
+  if (!credentials) {
+    return (
+      <div className="flex items-center justify-center h-full text-muted-foreground">
+        Unable to load SMTP settings
+      </div>
+    )
+  }
+
+  const { connectionInfo, keys } = credentials
+
+  return (
+    <div className="h-full overflow-auto p-6 max-w-4xl">
+      <h1 className="text-2xl font-bold mb-6">SMTP Settings</h1>
+
+      <div className="space-y-6">
+        {/* Connection Information */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Connection Information</CardTitle>
+            <CardDescription>
+              Use these settings to configure your email client
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {connectionInfo.smtpEnabled && (
+              <>
+                <h4 className="font-medium mb-2">Outgoing Mail (SMTP)</h4>
+                <div className="grid grid-cols-2 gap-4 mb-4">
+                  <div>
+                    <label className="text-sm font-medium text-muted-foreground">Server</label>
+                    <p className="mt-1 font-mono text-sm">{connectionInfo.smtpServer}</p>
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium text-muted-foreground">Port (STARTTLS)</label>
+                    <p className="mt-1 font-mono text-sm">{connectionInfo.smtpPort}</p>
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium text-muted-foreground">Secure Port (SSL/TLS)</label>
+                    <p className="mt-1 font-mono text-sm">{connectionInfo.smtpSecurePort}</p>
+                  </div>
+                </div>
+              </>
+            )}
+
+            {connectionInfo.pop3Enabled && (
+              <>
+                <h4 className="font-medium mb-2">Incoming Mail (POP3)</h4>
+                <div className="grid grid-cols-2 gap-4 mb-4">
+                  <div>
+                    <label className="text-sm font-medium text-muted-foreground">Server</label>
+                    <p className="mt-1 font-mono text-sm">{connectionInfo.pop3Server}</p>
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium text-muted-foreground">Port</label>
+                    <p className="mt-1 font-mono text-sm">{connectionInfo.pop3Port}</p>
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium text-muted-foreground">Secure Port (SSL/TLS)</label>
+                    <p className="mt-1 font-mono text-sm">{connectionInfo.pop3SecurePort}</p>
+                  </div>
+                </div>
+              </>
+            )}
+
+            {connectionInfo.imapEnabled && (
+              <>
+                <h4 className="font-medium mb-2">Incoming Mail (IMAP)</h4>
+                <div className="grid grid-cols-2 gap-4 mb-4">
+                  <div>
+                    <label className="text-sm font-medium text-muted-foreground">Server</label>
+                    <p className="mt-1 font-mono text-sm">{connectionInfo.imapServer}</p>
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium text-muted-foreground">Port</label>
+                    <p className="mt-1 font-mono text-sm">{connectionInfo.imapPort}</p>
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium text-muted-foreground">Secure Port (SSL/TLS)</label>
+                    <p className="mt-1 font-mono text-sm">{connectionInfo.imapSecurePort}</p>
+                  </div>
+                </div>
+              </>
+            )}
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="text-sm font-medium text-muted-foreground">Username</label>
+                <p className="mt-1 font-mono text-sm">{connectionInfo.username}</p>
+              </div>
+              <div>
+                <label className="text-sm font-medium text-muted-foreground">Password</label>
+                <p className="mt-1 text-sm text-muted-foreground">Use generated API key</p>
+              </div>
+            </div>
+
+            <div className="border-t pt-4 mt-4">
+              <h4 className="text-sm font-medium mb-2">Setup Instructions</h4>
+              <ol className="text-sm text-muted-foreground space-y-1 list-decimal list-inside">
+                <li>Generate an API key below</li>
+                <li>Configure your email client with the server and port above</li>
+                <li>Use your email address as the username</li>
+                <li>Use the generated API key as the password</li>
+              </ol>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* API Keys */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <div>
+                <CardTitle>API Keys</CardTitle>
+                <CardDescription>
+                  Manage API keys for authentication ({keys.length} active)
+                </CardDescription>
+              </div>
+              {!isCreatingKey && (
+                <Button onClick={() => setIsCreatingKey(true)}>
+                  <Plus className="h-4 w-4 mr-1" />
+                  Generate Key
+                </Button>
+              )}
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {isCreatingKey && (
+                <div className="p-4 rounded border bg-muted/50 space-y-4">
+                  <div>
+                    <label className="text-sm font-medium mb-2 block">Key Name</label>
+                    <Input
+                      value={keyName}
+                      onChange={(e) => setKeyName(e.target.value)}
+                      placeholder="Key name (e.g., Work Laptop, iPhone)"
+                      onKeyDown={(e) => e.key === 'Enter' && selectedScopes.length > 0 && handleCreateKey()}
+                    />
+                  </div>
+
+                  <div>
+                    <label className="text-sm font-medium mb-2 block">Permissions</label>
+                    <div className="space-y-2">
+                      {scopeOptions.map(scope => (
+                        <label key={scope.value} className="flex items-start gap-2 cursor-pointer py-1">
+                          <input
+                            type="checkbox"
+                            checked={selectedScopes.includes(scope.value)}
+                            onChange={(e) => {
+                              if (e.target.checked) {
+                                setSelectedScopes([...selectedScopes, scope.value])
+                              } else {
+                                setSelectedScopes(selectedScopes.filter(s => s !== scope.value))
+                              }
+                            }}
+                            className="mt-1 w-4 h-4"
+                          />
+                          <div>
+                            <div className="font-medium text-sm">{scope.label}</div>
+                            <div className="text-xs text-muted-foreground">{scope.description}</div>
+                          </div>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="flex gap-2">
+                    <Button onClick={handleCreateKey} disabled={createKey.isPending || !keyName.trim() || selectedScopes.length === 0}>
+                      Create
+                    </Button>
+                    <Button variant="outline" onClick={() => {
+                      setIsCreatingKey(false)
+                      setKeyName('')
+                      setSelectedScopes(['smtp', 'pop3', 'imap', 'api:read', 'api:write'])
+                    }}>
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              )}
+
+              {keys.length > 0 ? (
+                keys.map((key) => (
+                  <div key={key.id} className="flex items-center justify-between p-4 rounded border">
+                    <div className="flex items-start gap-3">
+                      <KeyRound className="h-5 w-5 text-muted-foreground flex-shrink-0 mt-0.5" />
+                      <div>
+                        <p className="font-medium">{key.name}</p>
+                        <p className="text-sm text-muted-foreground">
+                          Created {formatDistanceToNow(new Date(key.createdAt), { addSuffix: true })}
+                          {key.lastUsedAt && (
+                            <> &middot; Last used {formatDistanceToNow(new Date(key.lastUsedAt), { addSuffix: true })}</>
+                          )}
+                        </p>
+                        <div className="flex flex-wrap gap-1 mt-1">
+                          {key.scopes.map(scope => (
+                            <span key={scope} className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">
+                              {scope}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => {
+                        if (confirm(`Revoke API key "${key.name}"? Email clients using this key will stop working.`)) {
+                          revokeKey.mutate(key.id)
+                        }
+                      }}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))
+              ) : (
+                <p className="text-sm text-muted-foreground text-center py-8">
+                  No API keys yet. Generate one to get started.
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Created Key Modal */}
+      <Dialog open={!!createdKey} onOpenChange={handleCloseKeyModal}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>API Key Created</DialogTitle>
+            <DialogDescription>
+              Save this API key securely. It cannot be retrieved later.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div>
+              <label className="text-sm font-medium">Key Name</label>
+              <p className="mt-1 text-sm">{createdKey?.name}</p>
+            </div>
+
+            <div>
+              <label className="text-sm font-medium">Permissions</label>
+              <div className="flex gap-1 mt-1">
+                {createdKey?.scopes.map(scope => (
+                  <span key={scope} className="text-xs bg-primary/10 text-primary px-2 py-1 rounded">
+                    {scope}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <label className="text-sm font-medium">API Key</label>
+              <div className="mt-1 flex gap-2">
+                <Input
+                  value={createdKey?.apiKey || ''}
+                  readOnly
+                  className="font-mono text-sm"
+                />
+                <Button variant="outline" size="icon" onClick={handleCopyKey}>
+                  {copiedKey ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                </Button>
+              </div>
+            </div>
+
+            <div className="bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-900 rounded p-3">
+              <p className="text-sm text-yellow-800 dark:text-yellow-200">
+                <strong>Important:</strong> This is the only time you'll see this API key.
+                Copy it now and store it securely.
+              </p>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button onClick={handleCloseKeyModal}>Done</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds monorepo structure with npm workspaces (`packages/*`, `web`, `desktop`)
- Creates `@relate/shared` package with shared UI components, mail components, API types, and utilities
- Updates web app to re-export from `@relate/shared` for backward compatibility
- Builds Tauri v2 desktop app for Windows with full email client functionality
- Implements Phase 5 desktop features: system tray, notifications, window persistence, SMTP settings, and preferences

## Desktop App Features

- **Inbox** - View, search, and manage emails with keyboard shortcuts
- **System tray** - Minimize to tray, unread badge count, tray menu (Show/Quit)
- **Native notifications** - Windows toast notifications for new emails (respects user preference)
- **Background polling** - 60-second interval checks for new emails, updates badge
- **Window state persistence** - Saves/restores window size and position
- **SMTP Settings** - Connection info display, API key generation with scope selection, key revocation
- **Preferences** - Theme selector (system/light/dark), minimize-to-tray toggle, notification toggle
- **Secure credentials** - API keys stored in Windows Credential Manager via keyring crate
- **Dark mode** - Follows system preference or manual override via settings
- **Keyboard shortcuts** - Ctrl+R (refresh), Delete (delete), Escape (back), / (search)

## Test plan

- [ ] Verify `npm install` works from repo root with workspaces
- [ ] Verify `npm run dev` in `web/` still works with shared package imports
- [ ] Verify `npm run tauri:dev` in `desktop/` launches the Tauri app
- [ ] Test login flow with server URL + API key
- [ ] Test inbox view, email selection, search, and keyboard shortcuts
- [ ] Test system tray icon, minimize-to-tray, and tray menu actions
- [ ] Test SMTP Settings: create API key, copy key, revoke key
- [ ] Test Preferences: theme switching, notification/tray toggles
- [ ] Verify window size/position is restored on restart
- [ ] Test `npm run tauri:build` produces MSI installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)