### PR TITLE
chore: rebrand Relate SMTP to Relate Mail

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_PREFIX: tyevco/relate-smtp
+  IMAGE_PREFIX: tyevco/relate-mail
 
 jobs:
   build-and-push:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Relate SMTP is a full-stack application that provides SMTP, POP3, and IMAP email servers with a web-based management interface. The system consists of five main components:
+Relate Mail is a full-stack application that provides SMTP, POP3, and IMAP email servers with a web-based management interface. The system consists of five main components:
 
 1. **API** (.NET 10.0 ASP.NET Core) - REST API for managing emails and users
 2. **SMTP Server** (.NET 10.0 Worker Service) - Custom SMTP server for receiving emails
@@ -165,7 +165,7 @@ docker compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml up
 ### Backend Environment Variables
 
 - `ConnectionStrings__DefaultConnection` - PostgreSQL database connection string
-  - Format: `host=localhost;port=5432;database=relate-smtp;user id=myuser;password=mypass`
+  - Format: `host=localhost;port=5432;database=relate-mail;user id=myuser;password=mypass`
 - `Oidc__Authority` - OIDC provider URL (optional, enables JWT auth)
 - `Oidc__Audience` - OIDC audience claim (optional)
 - `Cors__AllowedOrigins__0` - CORS origins (can add multiple with __1, __2, etc.)
@@ -273,7 +273,7 @@ Database stores:
 - SMTP API keys (BCrypt-hashed) for per-user authentication
 
 **Connection String Format:**
-- `host=localhost;port=5432;database=relate-smtp;user id=myuser;password=mypass`
+- `host=localhost;port=5432;database=relate-mail;user id=myuser;password=mypass`
 
 ## Email Client Setup
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Relate SMTP
+# Relate Mail
 
 A full-stack email server and management system with SMTP, POP3, IMAP, and REST API access.
 
@@ -38,10 +38,10 @@ All images are published to GitHub Container Registry:
 
 | Image | Purpose | Ports |
 |-------|---------|-------|
-| `ghcr.io/tyevco/relate-smtp-api` | REST API + Web UI | 8080 |
-| `ghcr.io/tyevco/relate-smtp-smtp` | SMTP Server | 587, 465 |
-| `ghcr.io/tyevco/relate-smtp-pop3` | POP3 Server | 110, 995 |
-| `ghcr.io/tyevco/relate-smtp-imap` | IMAP Server | 143, 993 |
+| `ghcr.io/tyevco/relate-mail-api` | REST API + Web UI | 8080 |
+| `ghcr.io/tyevco/relate-mail-smtp` | SMTP Server | 587, 465 |
+| `ghcr.io/tyevco/relate-mail-pop3` | POP3 Server | 110, 995 |
+| `ghcr.io/tyevco/relate-mail-imap` | IMAP Server | 143, 993 |
 
 ## Architecture
 
@@ -127,7 +127,7 @@ dotnet ef database update \
 
 ```bash
 # Set environment variables
-export GITHUB_REPOSITORY="tyevco/relate-smtp"
+export GITHUB_REPOSITORY="tyevco/relate-mail"
 export IMAGE_TAG="latest"  # or specific version like "v1.0.0"
 
 # Start services
@@ -153,7 +153,7 @@ docker compose up -d --build
 
 **Database (PostgreSQL):**
 ```bash
-ConnectionStrings__DefaultConnection=host=postgres;port=5432;database=relate-smtp;user id=postgres;password=postgres
+ConnectionStrings__DefaultConnection=host=postgres;port=5432;database=relate-mail;user id=postgres;password=postgres
 ```
 
 **OIDC Authentication (optional):**
@@ -299,7 +299,7 @@ git tag v1.0.0
 git push origin v1.0.0
 
 # Wait for GitHub Actions to build and publish
-# View progress at: https://github.com/tyevco/relate-smtp/actions
+# View progress at: https://github.com/tyevco/relate-mail/actions
 ```
 
 ### Image Tags Created
@@ -348,10 +348,10 @@ docker compose logs -f imap
 
 ```bash
 # Backup PostgreSQL database
-docker exec postgres pg_dump -U postgres relate-smtp > backup.sql
+docker exec postgres pg_dump -U postgres relate-mail > backup.sql
 
 # Restore
-docker exec -i postgres psql -U postgres relate-smtp < backup.sql
+docker exec -i postgres psql -U postgres relate-mail < backup.sql
 ```
 
 ### Health Checks
@@ -406,7 +406,7 @@ Verify PostgreSQL connection:
 
 ```bash
 # Test connection
-docker exec postgres psql -U postgres -d relate-smtp -c "SELECT 1;"
+docker exec postgres psql -U postgres -d relate-mail -c "SELECT 1;"
 
 # Check logs
 docker logs postgres
@@ -453,7 +453,7 @@ docker compose logs postgres
 ## Project Structure
 
 ```
-relate-smtp/
+relate-mail/
 ├── api/                          # Backend (.NET 10.0)
 │   ├── src/
 │   │   ├── Relate.Smtp.Api/     # REST API (serves bundled web frontend)
@@ -514,9 +514,9 @@ relate-smtp/
 
 ## Support
 
-- **Issues**: https://github.com/tyevco/relate-smtp/issues
-- **Packages**: https://github.com/tyevco/relate-smtp/pkgs
-- **Actions**: https://github.com/tyevco/relate-smtp/actions
+- **Issues**: https://github.com/tyevco/relate-mail/issues
+- **Packages**: https://github.com/tyevco/relate-mail/pkgs
+- **Actions**: https://github.com/tyevco/relate-mail/actions
 
 ## Contributing
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -42,10 +42,10 @@ WORKDIR /app
 COPY --from=build /app/api .
 
 # OCI Labels
-LABEL org.opencontainers.image.title="Relate SMTP API"
-LABEL org.opencontainers.image.description="REST API for Relate SMTP email management"
-LABEL org.opencontainers.image.vendor="Relate SMTP"
-LABEL org.opencontainers.image.source="https://github.com/tyevco/relate-smtp"
+LABEL org.opencontainers.image.title="Relate Mail API"
+LABEL org.opencontainers.image.description="REST API for Relate Mail email management"
+LABEL org.opencontainers.image.vendor="Relate Mail"
+LABEL org.opencontainers.image.source="https://github.com/tyevco/relate-mail"
 
 EXPOSE 8080
 ENV ASPNETCORE_URLS=http://+:8080
@@ -57,10 +57,10 @@ WORKDIR /app
 COPY --from=build /app/smtp .
 
 # OCI Labels
-LABEL org.opencontainers.image.title="Relate SMTP Server"
+LABEL org.opencontainers.image.title="Relate Mail SMTP Server"
 LABEL org.opencontainers.image.description="SMTP server for receiving emails"
-LABEL org.opencontainers.image.vendor="Relate SMTP"
-LABEL org.opencontainers.image.source="https://github.com/tyevco/relate-smtp"
+LABEL org.opencontainers.image.vendor="Relate Mail"
+LABEL org.opencontainers.image.source="https://github.com/tyevco/relate-mail"
 
 EXPOSE 587 465
 ENTRYPOINT ["dotnet", "Relate.Smtp.SmtpHost.dll"]
@@ -71,10 +71,10 @@ WORKDIR /app
 COPY --from=build /app/pop3 .
 
 # OCI Labels
-LABEL org.opencontainers.image.title="Relate POP3 Server"
+LABEL org.opencontainers.image.title="Relate Mail POP3 Server"
 LABEL org.opencontainers.image.description="POP3 server for retrieving emails"
-LABEL org.opencontainers.image.vendor="Relate SMTP"
-LABEL org.opencontainers.image.source="https://github.com/tyevco/relate-smtp"
+LABEL org.opencontainers.image.vendor="Relate Mail"
+LABEL org.opencontainers.image.source="https://github.com/tyevco/relate-mail"
 
 EXPOSE 110 995
 ENTRYPOINT ["dotnet", "Relate.Smtp.Pop3Host.dll"]
@@ -85,10 +85,10 @@ WORKDIR /app
 COPY --from=build /app/imap .
 
 # OCI Labels
-LABEL org.opencontainers.image.title="Relate IMAP Server"
+LABEL org.opencontainers.image.title="Relate Mail IMAP Server"
 LABEL org.opencontainers.image.description="IMAP server for retrieving emails"
-LABEL org.opencontainers.image.vendor="Relate SMTP"
-LABEL org.opencontainers.image.source="https://github.com/tyevco/relate-smtp"
+LABEL org.opencontainers.image.vendor="Relate Mail"
+LABEL org.opencontainers.image.source="https://github.com/tyevco/relate-mail"
 
 EXPOSE 143 993
 ENTRYPOINT ["dotnet", "Relate.Smtp.ImapHost.dll"]

--- a/api/src/Relate.Smtp.Api/appsettings.json
+++ b/api/src/Relate.Smtp.Api/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5432;Database=relate_smtp;Username=postgres;Password=postgres"
+    "DefaultConnection": "Host=localhost;Port=5432;Database=relate_mail;Username=postgres;Password=postgres"
   },
   "Oidc": {
     "Authority": "",

--- a/api/src/Relate.Smtp.ImapHost/Dockerfile
+++ b/api/src/Relate.Smtp.ImapHost/Dockerfile
@@ -22,8 +22,8 @@ COPY --from=build /app .
 # OCI Labels
 LABEL org.opencontainers.image.title="Relate IMAP Server"
 LABEL org.opencontainers.image.description="IMAP4rev2 server for retrieving emails"
-LABEL org.opencontainers.image.vendor="Relate SMTP"
-LABEL org.opencontainers.image.source="https://github.com/tyevco/relate-smtp"
+LABEL org.opencontainers.image.vendor="Relate Mail"
+LABEL org.opencontainers.image.source="https://github.com/tyevco/relate-mail"
 
 # IMAP ports: 143 (plain), 993 (SSL/TLS)
 EXPOSE 143 993

--- a/api/src/Relate.Smtp.ImapHost/appsettings.json
+++ b/api/src/Relate.Smtp.ImapHost/appsettings.json
@@ -6,7 +6,7 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5432;Database=relate_smtp;Username=postgres;Password=postgres"
+    "DefaultConnection": "Host=localhost;Port=5432;Database=relate_mail;Username=postgres;Password=postgres"
   },
   "Imap": {
     "ServerName": "localhost",

--- a/api/src/Relate.Smtp.Pop3Host/appsettings.Development.json
+++ b/api/src/Relate.Smtp.Pop3Host/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5432;Database=relate_smtp;Username=postgres;Password=postgres"
+    "DefaultConnection": "Host=localhost;Port=5432;Database=relate_mail;Username=postgres;Password=postgres"
   },
   "Pop3": {
     "ServerName": "localhost",

--- a/api/src/Relate.Smtp.Pop3Host/appsettings.json
+++ b/api/src/Relate.Smtp.Pop3Host/appsettings.json
@@ -6,7 +6,7 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5432;Database=relate_smtp;Username=postgres;Password=postgres"
+    "DefaultConnection": "Host=localhost;Port=5432;Database=relate_mail;Username=postgres;Password=postgres"
   },
   "Pop3": {
     "ServerName": "localhost",

--- a/api/src/Relate.Smtp.SmtpHost/appsettings.json
+++ b/api/src/Relate.Smtp.SmtpHost/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5432;Database=relate_smtp;Username=postgres;Password=postgres"
+    "DefaultConnection": "Host=localhost;Port=5432;Database=relate_mail;Username=postgres;Password=postgres"
   },
   "Smtp": {
     "ServerName": "localhost",

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,9 +1,9 @@
 # GitHub Container Registry (for docker-compose.ghcr.yml)
-GITHUB_REPOSITORY=tyevco/relate-smtp
+GITHUB_REPOSITORY=tyevco/relate-mail
 IMAGE_TAG=latest
 
 # Database Configuration (PostgreSQL)
-ConnectionStrings__DefaultConnection=host=postgres;port=5432;database=relate-smtp;user id=postgres;password=postgres
+ConnectionStrings__DefaultConnection=host=postgres;port=5432;database=relate-mail;user id=postgres;password=postgres
 
 # OIDC Authentication (optional - leave empty for dev mode)
 # Backend API Configuration

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -12,7 +12,7 @@ services:
       - "5000:8080"
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=relate_smtp;Username=postgres;Password=postgres
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=relate_mail;Username=postgres;Password=postgres
       - Cors__AllowedOrigins__0=http://localhost:5173
       - Cors__AllowedOrigins__1=http://localhost:3000
 

--- a/docker/docker-compose.ghcr.yml
+++ b/docker/docker-compose.ghcr.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=relate_smtp
+      - POSTGRES_DB=relate_mail
     volumes:
       - postgres-data:/var/lib/postgresql/data
     networks:
@@ -22,9 +22,9 @@ services:
       retries: 5
 
   api:
-    image: ghcr.io/${GITHUB_REPOSITORY:-tyevco/relate-smtp}-api:${IMAGE_TAG:-latest}
+    image: ghcr.io/${GITHUB_REPOSITORY:-tyevco/relate-mail}-api:${IMAGE_TAG:-latest}
     environment:
-      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=relate_smtp;Username=postgres;Password=postgres
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=relate_mail;Username=postgres;Password=postgres
       - Oidc__Authority=${OIDC_AUTHORITY:-}
       - Oidc__Audience=${OIDC_AUDIENCE:-}
     ports:
@@ -37,9 +37,9 @@ services:
         condition: service_healthy
 
   smtp:
-    image: ghcr.io/${GITHUB_REPOSITORY:-tyevco/relate-smtp}-smtp:${IMAGE_TAG:-latest}
+    image: ghcr.io/${GITHUB_REPOSITORY:-tyevco/relate-mail}-smtp:${IMAGE_TAG:-latest}
     environment:
-      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=relate_smtp;Username=postgres;Password=postgres
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=relate_mail;Username=postgres;Password=postgres
       - Smtp__ServerName=${SMTP_SERVER_NAME:-localhost}
       - Smtp__Port=587
       - Smtp__SecurePort=465
@@ -55,9 +55,9 @@ services:
         condition: service_healthy
 
   pop3:
-    image: ghcr.io/${GITHUB_REPOSITORY:-tyevco/relate-smtp}-pop3:${IMAGE_TAG:-latest}
+    image: ghcr.io/${GITHUB_REPOSITORY:-tyevco/relate-mail}-pop3:${IMAGE_TAG:-latest}
     environment:
-      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=relate_smtp;Username=postgres;Password=postgres
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=relate_mail;Username=postgres;Password=postgres
       - Pop3__ServerName=${POP3_SERVER_NAME:-localhost}
       - Pop3__Port=110
       - Pop3__SecurePort=995
@@ -73,9 +73,9 @@ services:
         condition: service_healthy
 
   imap:
-    image: ghcr.io/${GITHUB_REPOSITORY:-tyevco/relate-smtp}-imap:${IMAGE_TAG:-latest}
+    image: ghcr.io/${GITHUB_REPOSITORY:-tyevco/relate-mail}-imap:${IMAGE_TAG:-latest}
     environment:
-      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=relate_smtp;Username=postgres;Password=postgres
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=relate_mail;Username=postgres;Password=postgres
       - Imap__ServerName=${IMAP_SERVER_NAME:-localhost}
       - Imap__Port=143
       - Imap__SecurePort=993

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=relate_smtp
+      - POSTGRES_DB=relate_mail
     volumes:
       - postgres-data:/var/lib/postgresql/data
     networks:
@@ -24,7 +24,7 @@ services:
       dockerfile: api/Dockerfile
       target: api
     environment:
-      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=relate_smtp;Username=postgres;Password=postgres
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=relate_mail;Username=postgres;Password=postgres
       - Oidc__Authority=${OIDC_AUTHORITY:-}
       - Oidc__Audience=${OIDC_AUDIENCE:-}
     ports:
@@ -42,7 +42,7 @@ services:
       dockerfile: api/Dockerfile
       target: smtp
     environment:
-      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=relate_smtp;Username=postgres;Password=postgres
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=relate_mail;Username=postgres;Password=postgres
       - Smtp__ServerName=${SMTP_SERVER_NAME:-localhost}
       - Smtp__Port=587
       - Smtp__RequireAuthentication=true
@@ -62,7 +62,7 @@ services:
       dockerfile: api/Dockerfile
       target: pop3
     environment:
-      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=relate_smtp;Username=postgres;Password=postgres
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=relate_mail;Username=postgres;Password=postgres
       - Pop3__ServerName=${POP3_SERVER_NAME:-localhost}
       - Pop3__Port=110
       - Pop3__SecurePort=995
@@ -83,7 +83,7 @@ services:
       dockerfile: api/Dockerfile
       target: imap
     environment:
-      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=relate_smtp;Username=postgres;Password=postgres
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=relate_mail;Username=postgres;Password=postgres
       - Imap__ServerName=${IMAP_SERVER_NAME:-localhost}
       - Imap__Port=143
       - Imap__SecurePort=993

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,6 +1,6 @@
 # Relate Mail Mobile App
 
-React Native mobile application for Relate SMTP, built with Expo.
+React Native mobile application for Relate Mail, built with Expo.
 
 ## Prerequisites
 

--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -63,8 +63,8 @@ jest.mock('react-native-reanimated', () => {
 // Mock expo-constants
 jest.mock('expo-constants', () => ({
   expoConfig: {
-    name: 'relate-smtp-mobile',
-    slug: 'relate-smtp-mobile',
+    name: 'relate-mail-mobile',
+    slug: 'relate-mail-mobile',
   },
 }))
 

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "relate-smtp-mobile",
+  "name": "relate-mail-mobile",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "relate-smtp-mobile",
+      "name": "relate-mail-mobile",
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "relate-smtp-mobile",
+  "name": "relate-mail-mobile",
   "version": "1.0.0",
   "main": "expo-router/entry",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "relate-smtp-frontend",
+  "name": "relate-mail-frontend",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "relate-smtp-frontend",
+      "name": "relate-mail-frontend",
       "workspaces": [
         "packages/*",
         "web",
@@ -4276,7 +4276,7 @@
       "resolved": "desktop",
       "link": true
     },
-    "node_modules/relate-smtp-web": {
+    "node_modules/relate-mail-web": {
       "resolved": "web",
       "link": true
     },
@@ -4778,7 +4778,7 @@
       }
     },
     "web": {
-      "name": "relate-smtp-web",
+      "name": "relate-mail-web",
       "version": "0.0.0",
       "dependencies": {
         "@microsoft/signalr": "^8.0.7",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "relate-smtp-frontend",
+  "name": "relate-mail-frontend",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Relate SMTP</title>
+    <title>Relate Mail</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "relate-smtp-web",
+  "name": "relate-mail-web",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "relate-smtp-web",
+      "name": "relate-mail-web",
       "version": "0.0.0",
       "dependencies": {
         "@microsoft/signalr": "^8.0.7",

--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "relate-smtp-web",
+  "name": "relate-mail-web",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -30,7 +30,7 @@ self.addEventListener('push', (event) => {
   };
 
   event.waitUntil(
-    self.registration.showNotification(data.title || 'Relate SMTP', options)
+    self.registration.showNotification(data.title || 'Relate Mail', options)
   );
 });
 

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -36,7 +36,7 @@ function RootComponent() {
               <div className="flex items-center gap-4 lg:gap-6">
                 <Link to="/" className="flex items-center gap-2 font-semibold">
                   <Mail className="h-5 w-5" />
-                  <span className="hidden sm:inline">Relate SMTP</span>
+                  <span className="hidden sm:inline">Relate Mail</span>
                 </Link>
 
                 {/* Desktop Navigation */}

--- a/web/src/routes/login.tsx
+++ b/web/src/routes/login.tsx
@@ -42,7 +42,7 @@ function Login() {
             </div>
             <div>
               <CardTitle className="text-4xl font-bold">
-                Relate SMTP
+                Relate Mail
               </CardTitle>
               <CardDescription className="mt-3 text-base">
                 Please sign in to continue


### PR DESCRIPTION
## Summary
- Rebrand all user-facing references from "Relate SMTP" / "relate-smtp" / "relate_smtp" to "Relate Mail" / "relate-mail" / "relate_mail"
- Updates package names, web UI display strings, Docker/OCI labels, Docker Compose database names, appsettings connection strings, GitHub workflow image prefix, and documentation
- C# namespaces (`Relate.Smtp.*`) and DLL names are excluded as they are internal code identifiers

## Files changed (26 files)
- **Package names**: `package.json`, `web/package.json`, `mobile/package.json` + lock files
- **Web UI**: `web/index.html`, `__root.tsx`, `login.tsx`, `sw.js`
- **Docker**: `api/Dockerfile`, `api/src/Relate.Smtp.ImapHost/Dockerfile`, all `docker-compose*.yml`, `.env.example`
- **Appsettings**: API, SMTP, POP3, IMAP host appsettings
- **CI/CD**: `.github/workflows/docker-publish.yml`
- **Docs**: `README.md`, `CLAUDE.md`, `mobile/README.md`
- **Tests**: `mobile/jest.setup.js`

## Test plan
- [x] `dotnet build` — backend compiles with 0 errors
- [x] `npm install` — monorepo installs successfully
- [x] `npm run build:web` — web frontend builds successfully
- [x] Grep confirms no remaining `Relate SMTP` / `relate-smtp` / `relate_smtp` outside C# namespace files

🤖 Generated with [Claude Code](https://claude.com/claude-code)