### PR TITLE
feat: add SignalR real-time notifications to desktop app

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -16,6 +16,7 @@
     "@tauri-apps/api": "^2.5.0",
     "@tauri-apps/plugin-shell": "^2.2.0",
     "@tauri-apps/plugin-notification": "^2.2.1",
+    "@microsoft/signalr": "^8.0.7",
     "@tanstack/react-query": "^5.90.20",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -8,6 +8,7 @@ import { SmtpSettings } from './views/SmtpSettings'
 import { Login } from './views/Login'
 import { useTheme } from './hooks/useTheme'
 import { usePolling } from './hooks/usePolling'
+import { useSignalR } from './hooks/useSignalR'
 import { useWindowState } from './hooks/useWindowState'
 
 type View = 'inbox' | 'sent' | 'smtp-settings' | 'settings'
@@ -19,7 +20,10 @@ function App() {
   // Initialize theme (follows system by default)
   useTheme()
 
-  // Background polling for new emails (only when authenticated)
+  // Real-time notifications via SignalR (primary)
+  useSignalR(auth.isAuthenticated ? auth.serverUrl : null, auth.apiKey)
+
+  // Background polling as fallback for reconnection gaps
   usePolling(auth.isAuthenticated)
 
   // Persist window size and position

--- a/desktop/src/api/signalr.ts
+++ b/desktop/src/api/signalr.ts
@@ -1,0 +1,82 @@
+import * as signalR from '@microsoft/signalr'
+
+let connection: signalR.HubConnection | null = null
+
+/**
+ * Create and start a SignalR connection to the email hub.
+ * No-ops if already connected.
+ */
+export async function connect(serverUrl: string, apiKey: string): Promise<void> {
+  if (connection?.state === signalR.HubConnectionState.Connected) {
+    return
+  }
+
+  await disconnect()
+
+  const hubUrl = `${serverUrl}/hubs/email`
+
+  connection = new signalR.HubConnectionBuilder()
+    .withUrl(hubUrl, {
+      accessTokenFactory: () => apiKey,
+    })
+    .withAutomaticReconnect({
+      nextRetryDelayInMilliseconds: (retryContext) => {
+        // Exponential backoff: 0s, 2s, 4s, 8s, max 30s
+        return Math.min(
+          Math.pow(2, retryContext.previousRetryCount) * 1000,
+          30000,
+        )
+      },
+    })
+    .configureLogging(signalR.LogLevel.Warning)
+    .build()
+
+  await connection.start()
+  console.log('SignalR connected to', hubUrl)
+}
+
+/**
+ * Stop and discard the current connection.
+ */
+export async function disconnect(): Promise<void> {
+  if (connection) {
+    try {
+      await connection.stop()
+    } catch (error) {
+      console.error('Error disconnecting SignalR:', error)
+    }
+    connection = null
+  }
+}
+
+export function onNewEmail(handler: (emailId: string) => void): void {
+  connection?.on('NewEmail', handler)
+}
+
+export function onEmailUpdated(handler: (emailId: string) => void): void {
+  connection?.on('EmailUpdated', handler)
+}
+
+export function onEmailDeleted(handler: (emailId: string) => void): void {
+  connection?.on('EmailDeleted', handler)
+}
+
+export function onUnreadCountChanged(handler: (count: number) => void): void {
+  connection?.on('UnreadCountChanged', handler)
+}
+
+export function onReconnecting(handler: (error?: Error) => void): void {
+  connection?.onreconnecting(handler)
+}
+
+export function onReconnected(handler: (connectionId?: string) => void): void {
+  connection?.onreconnected(handler)
+}
+
+export function onClose(handler: (error?: Error) => void): void {
+  connection?.onclose(handler)
+}
+
+export function getConnection(): signalR.HubConnection | null {
+  return connection
+}

--- a/desktop/src/hooks/usePolling.ts
+++ b/desktop/src/hooks/usePolling.ts
@@ -5,7 +5,7 @@ import { isPermissionGranted, requestPermission, sendNotification } from '@tauri
 import { apiGet } from '../api/client'
 import type { EmailListResponse } from '@relate/shared/api/types'
 
-const POLL_INTERVAL = 60_000 // 1 minute
+const POLL_INTERVAL = 300_000 // 5 minutes (SignalR is primary, polling is fallback)
 
 export function usePolling(enabled = true) {
   const queryClient = useQueryClient()

--- a/desktop/src/hooks/useSignalR.ts
+++ b/desktop/src/hooks/useSignalR.ts
@@ -1,0 +1,117 @@
+import { useEffect, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { invoke } from '@tauri-apps/api/core'
+import { isPermissionGranted, requestPermission, sendNotification } from '@tauri-apps/plugin-notification'
+import {
+  connect,
+  disconnect,
+  onNewEmail,
+  onEmailUpdated,
+  onEmailDeleted,
+  onUnreadCountChanged,
+  onReconnecting,
+  onReconnected,
+  onClose,
+} from '../api/signalr'
+
+export function useSignalR(serverUrl: string | null, apiKey: string | null) {
+  const queryClient = useQueryClient()
+  const [isConnected, setIsConnected] = useState(false)
+  const setupDoneRef = useRef(false)
+
+  useEffect(() => {
+    if (!serverUrl || !apiKey) {
+      return
+    }
+
+    let cancelled = false
+
+    async function setup() {
+      try {
+        await connect(serverUrl!, apiKey!)
+
+        if (cancelled) {
+          await disconnect()
+          return
+        }
+
+        setupDoneRef.current = true
+        setIsConnected(true)
+
+        onNewEmail(() => {
+          queryClient.invalidateQueries({ queryKey: ['emails'] })
+          notifyNewEmails()
+        })
+
+        onEmailUpdated((emailId: string) => {
+          queryClient.invalidateQueries({ queryKey: ['emails'] })
+          queryClient.invalidateQueries({ queryKey: ['email', emailId] })
+        })
+
+        onEmailDeleted(() => {
+          queryClient.invalidateQueries({ queryKey: ['emails'] })
+        })
+
+        onUnreadCountChanged((count: number) => {
+          invoke('set_badge_count', { count }).catch(() => {})
+        })
+
+        onReconnecting(() => {
+          setIsConnected(false)
+        })
+
+        onReconnected(() => {
+          setIsConnected(true)
+          // Refresh data after reconnection gap
+          queryClient.invalidateQueries({ queryKey: ['emails'] })
+        })
+
+        onClose(() => {
+          setIsConnected(false)
+        })
+      } catch (error) {
+        console.error('SignalR connection failed:', error)
+        setIsConnected(false)
+      }
+    }
+
+    setup()
+
+    return () => {
+      cancelled = true
+      if (setupDoneRef.current) {
+        disconnect()
+        setupDoneRef.current = false
+      }
+      setIsConnected(false)
+    }
+  }, [serverUrl, apiKey, queryClient])
+
+  return { isConnected }
+}
+
+async function notifyNewEmails() {
+  try {
+    const settings = await invoke<{ show_notifications: boolean }>('get_settings')
+    if (!settings.show_notifications) return
+  } catch {
+    // If settings unavailable, still show notification
+  }
+
+  try {
+    let permitted = await isPermissionGranted()
+    if (!permitted) {
+      const permission = await requestPermission()
+      permitted = permission === 'granted'
+    }
+
+    if (permitted) {
+      sendNotification({
+        title: 'Relate Mail',
+        body: 'You have a new email',
+      })
+    }
+  } catch {
+    // Notifications not available
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       "name": "relate-desktop",
       "version": "0.1.0",
       "dependencies": {
+        "@microsoft/signalr": "^8.0.7",
         "@relate/shared": "*",
         "@tanstack/react-query": "^5.90.20",
         "@tauri-apps/api": "^2.5.0",
@@ -1027,6 +1028,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@microsoft/signalr": {
+      "version": "8.0.17",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-8.0.17.tgz",
+      "integrity": "sha512-5pM6xPtKZNJLO0Tq5nQasVyPFwi/WBY3QB5uc/v3dIPTpS1JXQbaXAQAPxFoQ5rTBFE094w8bbqkp17F9ReQvA==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "eventsource": "^2.0.2",
+        "fetch-cookie": "^2.0.3",
+        "node-fetch": "^2.6.7",
+        "ws": "^7.5.10"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -2633,6 +2647,18 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3253,6 +3279,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3290,6 +3334,16 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fetch-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-2.2.0.tgz",
+      "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
+      "license": "Unlicense",
+      "dependencies": {
+        "set-cookie-parser": "^2.4.8",
+        "tough-cookie": "^4.0.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -4007,6 +4061,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -4163,6 +4237,18 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4171,6 +4257,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.4",
@@ -4280,6 +4372,12 @@
       "resolved": "web",
       "link": true
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4350,6 +4448,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4458,6 +4562,27 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -4528,6 +4653,15 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -4567,6 +4701,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/use-callback-ref": {
@@ -4687,6 +4831,22 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4711,6 +4871,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {
@@ -4951,36 +5132,6 @@
       },
       "peerDependenciesMeta": {
         "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "web/node_modules/@microsoft/signalr": {
-      "version": "8.0.7",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "eventsource": "^2.0.2",
-        "fetch-cookie": "^2.0.3",
-        "node-fetch": "^2.6.7",
-        "ws": "^7.4.5"
-      }
-    },
-    "web/node_modules/@microsoft/signalr/node_modules/ws": {
-      "version": "7.5.10",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
           "optional": true
         }
       }
@@ -5651,16 +5802,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "web/node_modules/abort-controller": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "web/node_modules/ansi-regex": {
       "version": "5.0.1",
       "dev": true,
@@ -5916,34 +6057,12 @@
         "@types/estree": "^1.0.0"
       }
     },
-    "web/node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "web/node_modules/eventsource": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "web/node_modules/expect-type": {
       "version": "1.3.0",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "web/node_modules/fetch-cookie": {
-      "version": "2.2.0",
-      "license": "Unlicense",
-      "dependencies": {
-        "set-cookie-parser": "^2.4.8",
-        "tough-cookie": "^4.0.0"
       }
     },
     "web/node_modules/fflate": {
@@ -6244,24 +6363,6 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "web/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "web/node_modules/normalize-path": {
       "version": "3.0.0",
       "dev": true,
@@ -6398,20 +6499,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "web/node_modules/psl": {
-      "version": "1.15.0",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
-    "web/node_modules/querystringify": {
-      "version": "2.2.0",
-      "license": "MIT"
-    },
     "web/node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
@@ -6483,10 +6570,6 @@
         "node": ">=0.10.0"
       }
     },
-    "web/node_modules/requires-port": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "web/node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "dev": true,
@@ -6516,10 +6599,6 @@
       "peerDependencies": {
         "seroval": "^1.0"
       }
-    },
-    "web/node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "license": "MIT"
     },
     "web/node_modules/shell-quote": {
       "version": "1.8.3",
@@ -6702,23 +6781,6 @@
         "node": ">=6"
       }
     },
-    "web/node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "web/node_modules/tr46": {
-      "version": "0.0.3",
-      "license": "MIT"
-    },
     "web/node_modules/tsx": {
       "version": "4.21.0",
       "dev": true,
@@ -6756,13 +6818,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "web/node_modules/universalify": {
-      "version": "0.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "web/node_modules/unplugin": {
       "version": "2.3.11",
       "dev": true,
@@ -6794,14 +6849,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/kettanaito"
-      }
-    },
-    "web/node_modules/url-parse": {
-      "version": "1.5.10",
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "web/node_modules/use-sync-external-store": {
@@ -6898,10 +6945,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "web/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "license": "BSD-2-Clause"
-    },
     "web/node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "dev": true,
@@ -6913,14 +6956,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "web/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "web/node_modules/why-is-node-running": {


### PR DESCRIPTION
## Summary

- Replace 60-second polling as the primary notification mechanism with a SignalR WebSocket connection to `/hubs/email` for instant email updates
- Add `@microsoft/signalr` dependency and create a connection manager (`desktop/src/api/signalr.ts`) with exponential backoff auto-reconnect
- Add `useSignalR` hook that invalidates TanStack Query caches on `NewEmail`, `EmailUpdated`, `EmailDeleted`, and `UnreadCountChanged` events, and shows native OS notifications via Tauri
- Retain polling as a 5-minute fallback for reconnection gaps (previously 1 minute as primary)

## Test plan

- [ ] Launch desktop app, connect to a server, verify "SignalR connected" appears in the dev console
- [ ] Send an email to the connected account, confirm the inbox refreshes instantly without waiting for the poll interval
- [ ] Verify native OS notification appears for new emails (when notifications are enabled in settings)
- [ ] Disconnect network briefly, verify reconnection and data refresh on reconnect
- [ ] Verify `npm run build` in `desktop/` succeeds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)