### PR TITLE
fix: address remaining code review issues (batch 8)

### DIFF
--- a/api/src/Relate.Smtp.Api/Controllers/ProfileController.cs
+++ b/api/src/Relate.Smtp.Api/Controllers/ProfileController.cs
@@ -1,3 +1,4 @@
+using System.Net.Mail;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Relate.Smtp.Api.Models;
@@ -55,11 +56,29 @@ public class ProfileController : ControllerBase
         [FromBody] AddEmailAddressRequest request,
         CancellationToken cancellationToken = default)
     {
+        // Validate email format
+        if (string.IsNullOrWhiteSpace(request.Address))
+        {
+            return BadRequest(new { error = "Email address is required" });
+        }
+
+        string normalizedAddress;
+        try
+        {
+            var mailAddress = new MailAddress(request.Address);
+            // Normalize to the parsed address
+            normalizedAddress = mailAddress.Address;
+        }
+        catch (FormatException)
+        {
+            return BadRequest(new { error = "Invalid email address format" });
+        }
+
         var user = await _userProvisioningService.GetOrCreateUserAsync(User, cancellationToken);
 
         // Check if address already exists
-        if (user.Email.Equals(request.Address, StringComparison.OrdinalIgnoreCase) ||
-            user.AdditionalAddresses.Any(a => a.Address.Equals(request.Address, StringComparison.OrdinalIgnoreCase)))
+        if (user.Email.Equals(normalizedAddress, StringComparison.OrdinalIgnoreCase) ||
+            user.AdditionalAddresses.Any(a => a.Address.Equals(normalizedAddress, StringComparison.OrdinalIgnoreCase)))
         {
             return BadRequest(new { error = "Email address already registered" });
         }
@@ -68,7 +87,7 @@ public class ProfileController : ControllerBase
         {
             Id = Guid.NewGuid(),
             UserId = user.Id,
-            Address = request.Address,
+            Address = normalizedAddress,
             IsVerified = false, // Would need email verification in production
             AddedAt = DateTimeOffset.UtcNow
         };
@@ -76,7 +95,7 @@ public class ProfileController : ControllerBase
         await _userRepository.AddEmailAddressAsync(address, cancellationToken);
 
         // Link existing emails to this user
-        await _emailRepository.LinkEmailsToUserAsync(user.Id, new[] { request.Address }, cancellationToken);
+        await _emailRepository.LinkEmailsToUserAsync(user.Id, new[] { normalizedAddress }, cancellationToken);
 
         return Ok(new EmailAddressDto(address.Id, address.Address, address.IsVerified, address.AddedAt));
     }

--- a/api/src/Relate.Smtp.Api/Controllers/PushSubscriptionsController.cs
+++ b/api/src/Relate.Smtp.Api/Controllers/PushSubscriptionsController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Options;
@@ -24,7 +25,12 @@ public class PushSubscriptionsController : ControllerBase
         _pushOptions = pushOptions;
     }
 
+    /// <summary>
+    /// Gets the VAPID public key for push notification subscription.
+    /// This endpoint is intentionally public because clients need the key before authentication.
+    /// </summary>
     [HttpGet("vapid-public-key")]
+    [AllowAnonymous]
     public ActionResult<VapidPublicKeyResponse> GetVapidPublicKey()
     {
         var publicKey = _pushOptions.Value.VapidPublicKey;

--- a/api/src/Relate.Smtp.Api/Models/BulkEmailOperationRequest.cs
+++ b/api/src/Relate.Smtp.Api/Models/BulkEmailOperationRequest.cs
@@ -5,3 +5,8 @@ public class BulkEmailOperationRequest
     public List<Guid> EmailIds { get; set; } = new();
     public bool? IsRead { get; set; }
 }
+
+public class BulkDeleteResponse
+{
+    public int DeletedCount { get; set; }
+}

--- a/api/src/Relate.Smtp.Api/Services/EmailFilterService.cs
+++ b/api/src/Relate.Smtp.Api/Services/EmailFilterService.cs
@@ -11,15 +11,18 @@ public class EmailFilterService
 {
     private readonly IEmailFilterRepository _filterRepository;
     private readonly IEmailLabelRepository _emailLabelRepository;
+    private readonly IEmailRepository _emailRepository;
     private readonly ILogger<EmailFilterService> _logger;
 
     public EmailFilterService(
         IEmailFilterRepository filterRepository,
         IEmailLabelRepository emailLabelRepository,
+        IEmailRepository emailRepository,
         ILogger<EmailFilterService> logger)
     {
         _filterRepository = filterRepository;
         _emailLabelRepository = emailLabelRepository;
+        _emailRepository = emailRepository;
         _logger = logger;
     }
 
@@ -132,12 +135,10 @@ public class EmailFilterService
         }
 
         // Action: Delete
-        // Note: We don't actually delete here, just mark for deletion
-        // The actual deletion would be handled by the calling code if needed
         if (filter.Delete)
         {
-            _logger.LogInformation("Filter '{FilterName}' marked email {EmailId} for deletion", filter.Name, email.Id);
-            // In a real implementation, you might set a flag or call a delete method
+            _logger.LogInformation("Filter '{FilterName}' deleting email {EmailId}", filter.Name, email.Id);
+            await _emailRepository.DeleteAsync(email.Id, cancellationToken);
         }
     }
 }

--- a/api/src/Relate.Smtp.ImapHost/Protocol/ImapSession.cs
+++ b/api/src/Relate.Smtp.ImapHost/Protocol/ImapSession.cs
@@ -5,6 +5,12 @@ namespace Relate.Smtp.ImapHost.Protocol;
 /// </summary>
 public class ImapSession
 {
+    /// <summary>
+    /// Maximum number of messages that can be marked for deletion in a single session.
+    /// Prevents unbounded memory growth in long-running sessions.
+    /// </summary>
+    public const int MaxDeletedMessages = 10000;
+
     public string ConnectionId { get; init; } = Guid.NewGuid().ToString();
     public DateTime ConnectedAt { get; init; } = DateTime.UtcNow;
     public DateTime LastActivityAt { get; set; } = DateTime.UtcNow;
@@ -32,6 +38,11 @@ public class ImapSession
 
     public bool IsTimedOut(TimeSpan timeout) =>
         DateTime.UtcNow - LastActivityAt > timeout;
+
+    /// <summary>
+    /// Returns true if the deleted UIDs collection has reached its maximum size.
+    /// </summary>
+    public bool IsDeletedUidsLimitReached => DeletedUids.Count >= MaxDeletedMessages;
 }
 
 /// <summary>

--- a/api/src/Relate.Smtp.Pop3Host/Protocol/Pop3Session.cs
+++ b/api/src/Relate.Smtp.Pop3Host/Protocol/Pop3Session.cs
@@ -2,6 +2,12 @@ namespace Relate.Smtp.Pop3Host.Protocol;
 
 public class Pop3Session
 {
+    /// <summary>
+    /// Maximum number of messages that can be marked for deletion in a single session.
+    /// Prevents unbounded memory growth in long-running sessions.
+    /// </summary>
+    public const int MaxDeletedMessages = 10000;
+
     public string ConnectionId { get; init; } = Guid.NewGuid().ToString();
     public DateTime ConnectedAt { get; init; } = DateTime.UtcNow;
     public DateTime LastActivityAt { get; set; } = DateTime.UtcNow;
@@ -15,6 +21,11 @@ public class Pop3Session
 
     public bool IsTimedOut(TimeSpan timeout) =>
         DateTime.UtcNow - LastActivityAt > timeout;
+
+    /// <summary>
+    /// Returns true if the deleted messages collection has reached its maximum size.
+    /// </summary>
+    public bool IsDeletedMessagesLimitReached => DeletedMessages.Count >= MaxDeletedMessages;
 }
 
 public class Pop3Message

--- a/desktop/src/hooks/useSignalR.ts
+++ b/desktop/src/hooks/useSignalR.ts
@@ -17,6 +17,7 @@ import {
 export function useSignalR(serverUrl: string | null, apiKey: string | null) {
   const queryClient = useQueryClient()
   const [isConnected, setIsConnected] = useState(false)
+  const [connectionError, setConnectionError] = useState<Error | null>(null)
   const setupDoneRef = useRef(false)
   const unsubscribersRef = useRef<(() => void)[]>([])
 
@@ -78,6 +79,9 @@ export function useSignalR(serverUrl: string | null, apiKey: string | null) {
       } catch (error) {
         console.error('SignalR connection failed:', error)
         setIsConnected(false)
+        if (!isCancelled) {
+          setConnectionError(error instanceof Error ? error : new Error(String(error)))
+        }
       }
     }
 
@@ -96,7 +100,7 @@ export function useSignalR(serverUrl: string | null, apiKey: string | null) {
     }
   }, [serverUrl, apiKey, queryClient])
 
-  return { isConnected }
+  return { isConnected, connectionError }
 }
 
 async function notifyNewEmails() {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -65,11 +65,12 @@ services:
       - relate-network
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "timeout 5 bash -c '</dev/tcp/localhost/587' || exit 1"]
+      # Verify SMTP server responds with 220 greeting
+      test: ["CMD-SHELL", "echo 'QUIT' | nc -w 5 localhost 587 | grep -q '^220' || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 5s
+      start_period: 10s
     depends_on:
       postgres:
         condition: service_healthy
@@ -94,11 +95,12 @@ services:
       - relate-network
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "timeout 5 bash -c '</dev/tcp/localhost/110' || exit 1"]
+      # Verify POP3 server responds with +OK greeting
+      test: ["CMD-SHELL", "echo 'QUIT' | nc -w 5 localhost 110 | grep -q '^+OK' || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 5s
+      start_period: 10s
     depends_on:
       postgres:
         condition: service_healthy
@@ -123,11 +125,12 @@ services:
       - relate-network
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "timeout 5 bash -c '</dev/tcp/localhost/143' || exit 1"]
+      # Verify IMAP server responds with * OK greeting
+      test: ["CMD-SHELL", "echo 'a001 LOGOUT' | nc -w 5 localhost 143 | grep -q '^\\* OK' || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 5s
+      start_period: 10s
     depends_on:
       postgres:
         condition: service_healthy

--- a/mobile/lib/auth/oidc.ts
+++ b/mobile/lib/auth/oidc.ts
@@ -12,8 +12,10 @@ const redirectUri = AuthSession.makeRedirectUri({
   path: "auth/callback",
 });
 
-// Debug: log the redirect URI at module load
-console.log("[OIDC] Redirect URI:", redirectUri);
+// Debug: log the redirect URI at module load (dev only)
+if (__DEV__) {
+  console.log("[OIDC] Redirect URI:", redirectUri);
+}
 
 export interface OidcResult {
   accessToken: string;
@@ -100,12 +102,13 @@ export async function discoverServer(
 export async function performOidcAuth(
   oidcConfig: OidcConfig
 ): Promise<OidcResult> {
-  console.log("[OIDC] Starting auth with config:", {
-    authority: oidcConfig.authority,
-    clientId: oidcConfig.clientId,
-    scopes: oidcConfig.scopes,
-    redirectUri,
-  });
+  if (__DEV__) {
+    console.log("[OIDC] Starting auth with config:", {
+      authority: oidcConfig.authority,
+      clientId: oidcConfig.clientId,
+      scopes: oidcConfig.scopes,
+    });
+  }
 
   // Validate required config
   if (!oidcConfig.authority) {
@@ -116,9 +119,7 @@ export async function performOidcAuth(
   }
 
   // Discover OIDC endpoints
-  console.log("[OIDC] Fetching discovery from:", oidcConfig.authority);
   const discovery = await AuthSession.fetchDiscoveryAsync(oidcConfig.authority);
-  console.log("[OIDC] Discovery result:", discovery);
 
   // Create auth request with PKCE (AuthSession handles verifier/challenge internally)
   const authRequest = new AuthSession.AuthRequest({

--- a/web/src/routes/smtp-settings.tsx
+++ b/web/src/routes/smtp-settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useAuth } from 'react-oidc-context'
 import { getConfig } from '@/config'
@@ -34,6 +34,16 @@ function SmtpSettingsPage() {
   const [selectedScopes, setSelectedScopes] = useState<string[]>(['smtp', 'pop3', 'imap', 'api:read', 'api:write'])
   const [createdKey, setCreatedKey] = useState<{ apiKey: string; name: string; scopes: string[] } | null>(null)
   const [copiedKey, setCopiedKey] = useState(false)
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) {
+        clearTimeout(copyTimeoutRef.current)
+      }
+    }
+  }, [])
 
   const scopeOptions = [
     { value: 'smtp', label: 'SMTP', description: 'Send emails via SMTP server' },
@@ -60,7 +70,11 @@ function SmtpSettingsPage() {
     if (createdKey) {
       await navigator.clipboard.writeText(createdKey.apiKey)
       setCopiedKey(true)
-      setTimeout(() => setCopiedKey(false), 2000)
+      // Clear any existing timeout
+      if (copyTimeoutRef.current) {
+        clearTimeout(copyTimeoutRef.current)
+      }
+      copyTimeoutRef.current = setTimeout(() => setCopiedKey(false), 2000)
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes 14 issues identified in code review (2 high priority security, 11 medium priority bugs, 1 infrastructure):

### Security (High Priority)
- **#97** - Add `[AllowAnonymous]` to VAPID public key endpoint with documentation explaining why it's intentionally public
- **#98** - Wrap sensitive auth metadata logs in `__DEV__` checks on mobile (token lengths, API key presence, OIDC config)

### Backend Bugs
- **#128** - Fix stream disposal in POP3/IMAP handlers (changed to `leaveOpen: false` + explicit flush in finally)
- **#99** - Implement email filter delete action (was logging-only no-op)
- **#111** - Track actual deletion count in BulkDelete, return count, only notify for deleted emails
- **#104** - Add 10,000 limit to deleted message collections to prevent unbounded memory growth
- **#101** - Add email format validation using `System.Net.Mail.MailAddress` parsing

### Frontend Bugs
- **#102** - Fix setTimeout cleanup in smtp-settings.tsx with useRef and cleanup effect
- **#105** - Add 30-second fetch timeout on mobile using AbortController
- **#109** - Fix SignalR promise handling with isMounted flag to prevent state updates after unmount
- **#106** - Replace SignalR busy-wait polling loop with Promise-based waiting
- **#107** - Expose `connectionError` state from desktop useSignalR hook for error boundary integration

### Infrastructure
- **#114** - Improve Docker healthchecks to verify protocol greetings (SMTP: 220, POP3: +OK, IMAP: * OK)

## Test plan
- [x] Backend build passes
- [x] Backend unit tests pass (130 tests)
- [x] Web lint passes (warnings only)
- [x] Web tests pass (181 tests)
- [x] Mobile lint passes (warnings only)
- [x] Mobile tests pass (222 tests)
- [x] Desktop lint passes (warnings only)
- [x] Docker compose config validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)