### PR TITLE
Replace Gitleaks with TruffleHog for secret scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
               - 'web/**'
               - 'docker/**'
 
-  # Secret scanning with Gitleaks
+  # Secret scanning with TruffleHog
   secret-scan:
     name: Secret Scanning
     runs-on: ubuntu-latest
@@ -52,10 +52,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run TruffleHog
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --only-verified
 
   # Backend build
   backend-build:


### PR DESCRIPTION
## Summary
This PR replaces the Gitleaks secret scanning tool with TruffleHog in the CI/CD pipeline, improving secret detection capabilities with verified results only.

## Key Changes
- Replaced `gitleaks/gitleaks-action@v2` with `trufflesecurity/trufflehog@main`
- Updated the secret scanning step configuration:
  - Changed from `env` to `with` for passing parameters
  - Removed `GITHUB_TOKEN` environment variable
  - Added `extra_args: --only-verified` to filter results to verified secrets only
- Updated workflow comments to reflect the new tool

## Implementation Details
TruffleHog is configured with the `--only-verified` flag to reduce false positives by only reporting secrets that have been verified as valid. This provides higher confidence in detected secrets compared to the previous Gitleaks implementation.

https://claude.ai/code/session_01WANvokFwMcw9KG2iQJ6eQA