### PR TITLE
Add API key rotation feature with age-based warnings

### DIFF
--- a/mobile/app/(main)/(tabs)/settings.tsx
+++ b/mobile/app/(main)/(tabs)/settings.tsx
@@ -9,16 +9,29 @@ import {
   ChevronRight,
   LogOut,
   Info,
+  AlertTriangle,
 } from "lucide-react-native";
 import { useProfile } from "@/lib/api/hooks";
 import { useActiveAccount, useAccountStore } from "@/lib/auth/account-store";
 import { Avatar } from "@/components/ui/avatar";
 import { Card, CardContent } from "@/components/ui/card";
 
+const KEY_AGE_WARNING_DAYS = 90;
+
+function isKeyOld(createdAt: string): boolean {
+  const created = new Date(createdAt);
+  const now = new Date();
+  const ageDays = Math.floor(
+    (now.getTime() - created.getTime()) / (1000 * 60 * 60 * 24)
+  );
+  return ageDays >= KEY_AGE_WARNING_DAYS;
+}
+
 export default function SettingsScreen() {
   const account = useActiveAccount();
   const { data: profile } = useProfile();
   const removeAccount = useAccountStore((state) => state.removeAccount);
+  const activeKeyIsOld = account ? isKeyOld(account.createdAt) : false;
 
   const handleLogout = () => {
     Alert.alert(
@@ -74,6 +87,29 @@ export default function SettingsScreen() {
               </View>
             </CardContent>
           </Card>
+
+          {/* Key age warning */}
+          {activeKeyIsOld && (
+            <TouchableOpacity
+              onPress={() => router.push("/(main)/api-keys")}
+              activeOpacity={0.7}
+            >
+              <Card className="mb-6 border-amber-300 bg-amber-50">
+                <CardContent className="flex-row items-center gap-3 py-3">
+                  <AlertTriangle size={20} color="#d97706" />
+                  <View className="flex-1">
+                    <Text className="font-medium text-amber-800">
+                      API key rotation recommended
+                    </Text>
+                    <Text className="text-sm text-amber-700">
+                      Your active API key is over 90 days old. Tap to rotate it.
+                    </Text>
+                  </View>
+                  <ChevronRight size={20} color="#d97706" />
+                </CardContent>
+              </Card>
+            </TouchableOpacity>
+          )}
 
           {/* Menu Items */}
           <Text className="mb-2 px-1 text-sm font-medium text-muted-foreground">

--- a/mobile/app/(main)/api-keys.tsx
+++ b/mobile/app/(main)/api-keys.tsx
@@ -1,18 +1,46 @@
+import { useState } from "react";
 import { View, Text, TouchableOpacity, ScrollView, Alert } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { router } from "expo-router";
-import { ArrowLeft, Key, Trash2 } from "lucide-react-native";
-import { useSmtpCredentials, useRevokeSmtpApiKey } from "@/lib/api/hooks";
+import { ArrowLeft, Key, Trash2, RefreshCw, AlertTriangle } from "lucide-react-native";
+import { useSmtpCredentials, useRevokeSmtpApiKey, useRotateSmtpApiKey } from "@/lib/api/hooks";
+import { useActiveAccount, useAccountStore } from "@/lib/auth/account-store";
+import { storeApiKey } from "@/lib/auth/secure-storage";
 import { Loading } from "@/components/ui/loading";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Card, CardContent } from "@/components/ui/card";
 import { formatDate } from "@/lib/utils";
+import type { SmtpApiKey } from "@/lib/api/types";
+
+const KEY_AGE_WARNING_DAYS = 90;
+
+function getKeyAgeDays(createdAt: string): number {
+  const created = new Date(createdAt);
+  const now = new Date();
+  return Math.floor((now.getTime() - created.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+function isKeyOld(createdAt: string): boolean {
+  return getKeyAgeDays(createdAt) >= KEY_AGE_WARNING_DAYS;
+}
 
 export default function ApiKeysScreen() {
   const { data, isLoading, isError } = useSmtpCredentials();
   const revokeKey = useRevokeSmtpApiKey();
+  const rotateKey = useRotateSmtpApiKey();
+  const account = useActiveAccount();
+  const updateAccount = useAccountStore((state) => state.updateAccount);
+  const [rotatingKeyId, setRotatingKeyId] = useState<string | null>(null);
 
   const handleRevokeKey = (keyId: string, keyName: string) => {
+    if (account && keyId === account.apiKeyId) {
+      Alert.alert(
+        "Cannot Revoke Active Key",
+        "This key is used by this device. Rotate it instead to replace it with a new key."
+      );
+      return;
+    }
+
     Alert.alert(
       "Revoke API Key",
       `Are you sure you want to revoke "${keyName}"? This action cannot be undone, and any devices using this key will lose access.`,
@@ -22,6 +50,52 @@ export default function ApiKeysScreen() {
           text: "Revoke",
           style: "destructive",
           onPress: () => revokeKey.mutate(keyId),
+        },
+      ]
+    );
+  };
+
+  const handleRotateKey = (apiKey: SmtpApiKey) => {
+    const isActiveKey = account && apiKey.id === account.apiKeyId;
+
+    Alert.alert(
+      "Rotate API Key",
+      isActiveKey
+        ? `This will replace "${apiKey.name}" with a new key. This device will automatically use the new key. The old key will be revoked.`
+        : `This will replace "${apiKey.name}" with a new key. Any devices using the old key will need to be updated. The old key will be revoked.`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Rotate",
+          onPress: async () => {
+            setRotatingKeyId(apiKey.id);
+            try {
+              const result = await rotateKey.mutateAsync(apiKey.id);
+
+              // If this was the active account's key, update local storage
+              if (isActiveKey && account) {
+                await storeApiKey(account.id, result.apiKey);
+                updateAccount(account.id, {
+                  apiKeyId: result.id,
+                  createdAt: result.createdAt,
+                });
+              }
+
+              Alert.alert(
+                "Key Rotated",
+                isActiveKey
+                  ? "Your API key has been rotated. This device is now using the new key."
+                  : "The API key has been rotated. Update any devices that were using the old key."
+              );
+            } catch {
+              Alert.alert(
+                "Rotation Failed",
+                "Failed to rotate the API key. Please try again."
+              );
+            } finally {
+              setRotatingKeyId(null);
+            }
+          },
         },
       ]
     );
@@ -63,6 +137,7 @@ export default function ApiKeysScreen() {
   }
 
   const keys = data?.keys ?? [];
+  const oldKeys = keys.filter((k) => isKeyOld(k.createdAt));
 
   return (
     <SafeAreaView className="flex-1 bg-background">
@@ -82,59 +157,116 @@ export default function ApiKeysScreen() {
         />
       ) : (
         <ScrollView className="flex-1 p-4">
+          {/* Key age warning banner */}
+          {oldKeys.length > 0 && (
+            <Card className="mb-4 border-amber-300 bg-amber-50">
+              <CardContent className="flex-row items-start gap-3 py-3">
+                <AlertTriangle size={20} color="#d97706" />
+                <View className="flex-1">
+                  <Text className="font-medium text-amber-800">
+                    {oldKeys.length === 1
+                      ? "1 key is older than 90 days"
+                      : `${oldKeys.length} keys are older than 90 days`}
+                  </Text>
+                  <Text className="mt-1 text-sm text-amber-700">
+                    Consider rotating old keys to maintain security. Tap the
+                    rotate button on a key to replace it.
+                  </Text>
+                </View>
+              </CardContent>
+            </Card>
+          )}
+
           <Text className="mb-2 px-1 text-sm font-medium text-muted-foreground">
             {keys.length} key{keys.length !== 1 ? "s" : ""}
           </Text>
 
           <View className="gap-3">
-            {keys.map((key) => (
-              <Card key={key.id}>
-                <CardContent className="py-4">
-                  <View className="flex-row items-start justify-between">
-                    <View className="flex-1">
-                      <View className="flex-row items-center gap-2">
-                        <Key size={18} color="#64748b" />
-                        <Text className="font-semibold text-foreground">
-                          {key.name}
-                        </Text>
-                      </View>
+            {keys.map((key) => {
+              const ageDays = getKeyAgeDays(key.createdAt);
+              const old = ageDays >= KEY_AGE_WARNING_DAYS;
+              const isActive = account?.apiKeyId === key.id;
+              const isRotating = rotatingKeyId === key.id;
 
-                      <View className="mt-2 flex-row flex-wrap gap-1">
-                        {key.scopes.map((scope) => (
-                          <View
-                            key={scope}
-                            className="rounded bg-secondary px-2 py-0.5"
-                          >
-                            <Text className="text-xs text-secondary-foreground">
-                              {scope}
-                            </Text>
-                          </View>
-                        ))}
-                      </View>
-
-                      <View className="mt-2 gap-0.5">
-                        <Text className="text-xs text-muted-foreground">
-                          Created: {formatDate(key.createdAt)}
-                        </Text>
-                        {key.lastUsedAt && (
-                          <Text className="text-xs text-muted-foreground">
-                            Last used: {formatDate(key.lastUsedAt)}
+              return (
+                <Card key={key.id} className={old ? "border-amber-300" : ""}>
+                  <CardContent className="py-4">
+                    <View className="flex-row items-start justify-between">
+                      <View className="flex-1">
+                        <View className="flex-row items-center gap-2">
+                          <Key size={18} color="#64748b" />
+                          <Text className="font-semibold text-foreground">
+                            {key.name}
                           </Text>
-                        )}
+                          {isActive && (
+                            <View className="rounded bg-primary/10 px-2 py-0.5">
+                              <Text className="text-xs font-medium text-primary">
+                                This device
+                              </Text>
+                            </View>
+                          )}
+                        </View>
+
+                        <View className="mt-2 flex-row flex-wrap gap-1">
+                          {key.scopes.map((scope) => (
+                            <View
+                              key={scope}
+                              className="rounded bg-secondary px-2 py-0.5"
+                            >
+                              <Text className="text-xs text-secondary-foreground">
+                                {scope}
+                              </Text>
+                            </View>
+                          ))}
+                        </View>
+
+                        <View className="mt-2 gap-0.5">
+                          <View className="flex-row items-center gap-1">
+                            <Text className="text-xs text-muted-foreground">
+                              Created: {formatDate(key.createdAt)}
+                            </Text>
+                            {old && (
+                              <View className="flex-row items-center gap-1 rounded bg-amber-100 px-1.5 py-0.5">
+                                <AlertTriangle size={10} color="#d97706" />
+                                <Text className="text-xs font-medium text-amber-700">
+                                  {ageDays}d old
+                                </Text>
+                              </View>
+                            )}
+                          </View>
+                          {key.lastUsedAt && (
+                            <Text className="text-xs text-muted-foreground">
+                              Last used: {formatDate(key.lastUsedAt)}
+                            </Text>
+                          )}
+                        </View>
+                      </View>
+
+                      <View className="flex-row items-center gap-1">
+                        <TouchableOpacity
+                          onPress={() => handleRotateKey(key)}
+                          className="p-2"
+                          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                          disabled={isRotating}
+                        >
+                          <RefreshCw
+                            size={20}
+                            color={isRotating ? "#94a3b8" : "#3b82f6"}
+                          />
+                        </TouchableOpacity>
+                        <TouchableOpacity
+                          onPress={() => handleRevokeKey(key.id, key.name)}
+                          className="p-2"
+                          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                        >
+                          <Trash2 size={20} color="#dc2626" />
+                        </TouchableOpacity>
                       </View>
                     </View>
-
-                    <TouchableOpacity
-                      onPress={() => handleRevokeKey(key.id, key.name)}
-                      className="p-2"
-                      hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-                    >
-                      <Trash2 size={20} color="#dc2626" />
-                    </TouchableOpacity>
-                  </View>
-                </CardContent>
-              </Card>
-            ))}
+                  </CardContent>
+                </Card>
+              );
+            })}
           </View>
 
           <Card className="mt-6 bg-secondary/30">

--- a/mobile/lib/api/__tests__/hooks.test.tsx
+++ b/mobile/lib/api/__tests__/hooks.test.tsx
@@ -17,6 +17,7 @@ import {
   useSmtpCredentials,
   useCreateSmtpApiKey,
   useRevokeSmtpApiKey,
+  useRotateSmtpApiKey,
   useLabels,
   usePreferences,
   useUpdatePreferences,
@@ -284,6 +285,20 @@ describe('API Hooks', () => {
 
       it('returns mutation result when called', async () => {
         const { result } = renderHook(() => useRevokeSmtpApiKey(), {
+          wrapper: createWrapper(),
+        })
+        expect(result.current).toBeDefined()
+        expect(result.current.mutateAsync).toBeDefined()
+      })
+    })
+
+    describe('useRotateSmtpApiKey', () => {
+      it('is a function', () => {
+        expect(typeof useRotateSmtpApiKey).toBe('function')
+      })
+
+      it('returns mutation result when called', async () => {
+        const { result } = renderHook(() => useRotateSmtpApiKey(), {
           wrapper: createWrapper(),
         })
         expect(result.current).toBeDefined()

--- a/mobile/lib/api/hooks.ts
+++ b/mobile/lib/api/hooks.ts
@@ -180,6 +180,23 @@ export function useRevokeSmtpApiKey() {
   });
 }
 
+export function useRotateSmtpApiKey() {
+  const queryClient = useQueryClient();
+  const account = useActiveAccount();
+
+  return useMutation({
+    mutationFn: async (keyId: string) =>
+      withApi((api) =>
+        api.post<CreatedApiKey>(`/smtp-credentials/${keyId}/rotate`, {})
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["smtp-credentials", account?.id],
+      });
+    },
+  });
+}
+
 // Label hooks
 export function useLabels() {
   const account = useActiveAccount();


### PR DESCRIPTION
## Summary
This PR adds the ability to rotate API keys, allowing users to replace old keys with new ones while maintaining the same scopes and name. It includes security warnings for keys older than 90 days across both the backend API and mobile app.

## Key Changes

### Backend (API)
- Added `RotateApiKey` endpoint (`POST /smtp-credentials/{keyId}/rotate`) that:
  - Creates a new API key with identical scopes and name as the existing key
  - Revokes the old key atomically
  - Returns the new key in plaintext (shown only once)

### Mobile App
- **API Keys Screen** (`api-keys.tsx`):
  - Added rotate button for each key alongside the existing revoke button
  - Displays key age in days with visual warning for keys ≥90 days old
  - Shows "This device" badge for the active account's key
  - Prevents revoking the active key (suggests rotation instead)
  - Automatically updates local storage when rotating the active key
  - Added warning banner when multiple old keys exist

- **Settings Screen** (`settings.tsx`):
  - Added prominent warning card when active key is ≥90 days old
  - Card links directly to API keys management screen

- **Hooks** (`hooks.ts`):
  - Added `useRotateSmtpApiKey()` mutation hook for key rotation
  - Invalidates credentials query on successful rotation

### Utilities
- Added `KEY_AGE_WARNING_DAYS` constant (90 days) used consistently across screens
- Added helper functions: `isKeyOld()` and `getKeyAgeDays()` for age calculations

## Implementation Details
- Key rotation is atomic: new key is created before old key is revoked
- Active device keys are automatically updated in secure storage after rotation
- Users cannot revoke their active key but are guided to rotate instead
- Visual indicators (amber/warning colors) highlight old keys throughout the UI
- Age warnings appear in multiple places (settings, api-keys list, individual key cards) for discoverability

https://claude.ai/code/session_012WaSnDTcJKS6agtowrFtxa