### PR TITLE
feat(helm): add chart for api, smtp/pop3/imap, web, and postgresql

### DIFF
--- a/helm/relate-mail/.helmignore
+++ b/helm/relate-mail/.helmignore
@@ -1,0 +1,11 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.idea/
+.vscode/
+*.tmproj
+*.swp
+*.bak
+*.tgz
+.tmp/

--- a/helm/relate-mail/Chart.yaml
+++ b/helm/relate-mail/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: relate-mail
+description: Relate Mail — REST API plus SMTP, POP3, and IMAP servers backed by PostgreSQL.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+kubeVersion: ">=1.25.0-0"
+home: https://github.com/four-robots/relate-mail
+sources:
+  - https://github.com/four-robots/relate-mail
+keywords:
+  - email
+  - smtp
+  - pop3
+  - imap
+  - mail
+maintainers:
+  - name: four-robots

--- a/helm/relate-mail/README.md
+++ b/helm/relate-mail/README.md
@@ -1,0 +1,221 @@
+# relate-mail Helm chart
+
+Deploys the Relate Mail platform — REST API, SMTP, POP3, IMAP — to Kubernetes,
+with an optional in-chart PostgreSQL.
+
+## TL;DR
+
+```bash
+helm install relate-mail ./helm/relate-mail \
+  --namespace relate-mail --create-namespace \
+  --set postgresql.auth.password=changeme \
+  --set smtp.serverName=smtp.example.com \
+  --set pop3.serverName=pop3.example.com \
+  --set imap.serverName=imap.example.com
+```
+
+## Layout
+
+Each protocol host runs as its own Deployment with its own Service so that
+SMTP/POP3/IMAP ports can be exposed via separate `LoadBalancer` Services
+(typical), while the HTTP API stays internal behind an `Ingress`.
+
+| Component  | Workload     | Default Service type | Ports                                   |
+|------------|--------------|----------------------|-----------------------------------------|
+| api        | Deployment   | ClusterIP            | 8080 (HTTP)                             |
+| smtp       | Deployment   | LoadBalancer         | 587, 465, optionally 25 (MX)            |
+| pop3       | Deployment   | LoadBalancer         | 110, 995                                |
+| imap       | Deployment   | LoadBalancer         | 143, 993                                |
+| web        | Deployment   | ClusterIP            | 8080 (HTTP, disabled by default)        |
+| postgresql | StatefulSet  | Headless ClusterIP   | 5432                                    |
+
+The SMTP, POP3, and IMAP hosts each expose an internal HTTP health endpoint
+on a separate port (8081, 8082, 8083) used for liveness/readiness probes.
+
+## Database
+
+You can either let the chart deploy PostgreSQL or point at an existing one.
+
+**In-chart (default, dev only):**
+```yaml
+postgresql:
+  enabled: true
+  auth:
+    password: changeme
+```
+
+**External:**
+```yaml
+postgresql:
+  enabled: false
+database:
+  connectionString: "Host=db.internal;Port=5432;Database=relate_mail;Username=relate;Password=..."
+```
+
+Or reference an existing `Secret`:
+```yaml
+postgresql:
+  enabled: false
+database:
+  existingSecret: relate-mail-db
+  existingSecretKey: connectionString
+```
+
+## Authentication
+
+OIDC is optional. When `oidc.authority` is empty the API runs in dev mode
+with no authentication.
+
+```yaml
+oidc:
+  authority: https://issuer.example.com/realms/relate
+  audience: relate-mail
+```
+
+The `internal.apiKey` value is the pre-shared key the SMTP host uses to call
+the API's `/internal` notification endpoint. Generate an API key with the
+`internal` scope in the database, then provide it inline or via `existingSecret`.
+
+## Images
+
+By default the chart pulls per-component images from GHCR:
+
+```
+ghcr.io/four-robots/relate-mail-api:<chart appVersion>
+ghcr.io/four-robots/relate-mail-smtp:<chart appVersion>
+ghcr.io/four-robots/relate-mail-pop3:<chart appVersion>
+ghcr.io/four-robots/relate-mail-imap:<chart appVersion>
+```
+
+Override globally:
+```yaml
+image:
+  registry: ghcr.io
+  repository: four-robots/relate-mail
+  tag: "1.2.3"
+```
+
+Or per component:
+```yaml
+api:
+  image:
+    repository: my-registry.example.com/relate-mail-api
+    tag: "1.2.3"
+```
+
+## SMTP MX (inbound internet mail)
+
+Disabled by default. Enable only when this deployment is the authoritative
+mail server for one or more domains:
+
+```yaml
+smtp:
+  mx:
+    enabled: true
+    port: 25
+    hostedDomains:
+      - example.com
+      - mail.example.com
+    validateRecipients: true
+```
+
+## Outbound delivery (relay through a smarthost)
+
+Relate Mail's queue processor (`DeliveryQueueProcessor`) is registered in
+every host that calls `AddInfrastructure` — so outbound `OutboundMail__*`
+config is delivered to all four deployments via a shared `ConfigMap` and
+`Secret`. With no relay configured, the SMTP daemon attempts direct-to-MX
+delivery, which is rarely accepted from cluster egress IPs (residential or
+cloud reputation, missing PTR, etc.). For real deliverability, point the
+service at a smarthost such as Resend, SES, SendGrid, Mailgun, or an
+internal Postfix relay.
+
+```yaml
+outbound:
+  enabled: true
+  relayHost: smtp.resend.com
+  relayPort: 587
+  relayUseTls: true
+  relayUsername: resend
+  relayPassword: re_xxxxxxxxxxxxxxxx
+  senderDomain: mail.example.com
+```
+
+Or use an existing `Secret` so the password isn't in your values file:
+
+```yaml
+outbound:
+  enabled: true
+  relayHost: email-smtp.us-east-1.amazonaws.com
+  relayPort: 587
+  relayUsername: AKIA...
+  existingSecret: relate-mail-relay
+  existingSecretKey: relayPassword
+  senderDomain: mail.example.com
+```
+
+When `relayHost` is empty, mail is queued and the daemon attempts
+direct MX delivery — fine for testing, generally not for production.
+
+## Web SPA
+
+The `web` component is **disabled by default** because the project does
+not yet publish a `relate-mail-web` image. Once it does, enable it as a
+separate pod so it can roll independently of the API/protocol hosts:
+
+```yaml
+web:
+  enabled: true
+  image:
+    # falls back to ghcr.io/four-robots/relate-mail-web:<chart appVersion>
+    tag: "1.2.3"
+  apiUrl: /api
+  oidc:
+    clientId: relate-mail-web
+    redirectUri: https://relate.example.com
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - host: relate.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+```
+
+`OIDC_AUTHORITY` is shared with the API via the top-level `oidc.authority`.
+`API_URL`, `OIDC_CLIENT_ID`, `OIDC_REDIRECT_URI`, and `OIDC_SCOPE` are passed
+as env vars; the image is expected to render them into `config.json` at
+container startup (see `docker/.env.example` in the project).
+
+If you want the SPA at `/` and the API at `/api` on the same host, point
+`web.ingress` at the user-facing host and add a path-based rule that
+forwards `/api` to the API Service — most ingress controllers handle this
+with a single Ingress resource (use `nginx.ingress.kubernetes.io/rewrite-target`
+or your controller's equivalent), or split it across two Ingress resources
+on the same host.
+
+## Ingress
+
+```yaml
+api:
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - host: api.relate.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: api-relate-tls
+        hosts:
+          - api.relate.example.com
+```
+
+## Render / lint
+
+```bash
+helm lint ./helm/relate-mail
+helm template demo ./helm/relate-mail --set postgresql.auth.password=x | less
+```

--- a/helm/relate-mail/templates/NOTES.txt
+++ b/helm/relate-mail/templates/NOTES.txt
@@ -1,0 +1,59 @@
+Relate Mail has been deployed as release {{ .Release.Name }} in namespace {{ .Release.Namespace }}.
+
+Components enabled:
+{{- if .Values.api.enabled }}
+  - API       (Service: {{ include "relate-mail.componentFullname" (list . "api") }}:{{ .Values.api.service.port }})
+{{- end }}
+{{- if .Values.smtp.enabled }}
+  - SMTP      (Service: {{ include "relate-mail.componentFullname" (list . "smtp") }} — submission {{ .Values.smtp.submissionPort }}, implicit-tls {{ .Values.smtp.implicitTlsPort }}{{ if .Values.smtp.mx.enabled }}, mx {{ .Values.smtp.mx.port }}{{ end }})
+{{- end }}
+{{- if .Values.pop3.enabled }}
+  - POP3      (Service: {{ include "relate-mail.componentFullname" (list . "pop3") }} — pop3 {{ .Values.pop3.port }}, pop3s {{ .Values.pop3.securePort }})
+{{- end }}
+{{- if .Values.imap.enabled }}
+  - IMAP      (Service: {{ include "relate-mail.componentFullname" (list . "imap") }} — imap {{ .Values.imap.port }}, imaps {{ .Values.imap.securePort }})
+{{- end }}
+{{- if .Values.web.enabled }}
+  - Web SPA   (Service: {{ include "relate-mail.componentFullname" (list . "web") }}:{{ .Values.web.service.port }})
+{{- end }}
+{{- if .Values.postgresql.enabled }}
+  - PostgreSQL (StatefulSet: {{ printf "%s-postgresql" (include "relate-mail.fullname" .) }})
+{{- end }}
+
+Reach the API:
+
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "relate-mail.componentFullname" (list . "api") }} 8080:{{ .Values.api.service.port }}
+  curl http://localhost:8080/healthz
+
+{{- if and .Values.api.enabled .Values.api.ingress.enabled }}
+
+The API is exposed via Ingress at:
+{{- range .Values.api.ingress.hosts }}
+  - http{{ if $.Values.api.ingress.tls }}s{{ end }}://{{ .host }}{{ (index .paths 0).path }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.smtp.mx.enabled }}
+
+WARNING: SMTP MX (port {{ .Values.smtp.mx.port }}) is ENABLED. Make sure smtp.mx.hostedDomains
+is set to the domains you actually host, or this will accept mail for nothing.
+{{- end }}
+
+{{- if and .Values.outbound.enabled (not .Values.outbound.relayHost) }}
+
+WARNING: outbound.enabled=true but outbound.relayHost is empty. The SMTP daemon
+will attempt direct-to-MX delivery from the pod's egress IP. Most providers
+will spam-flag or reject this. Set outbound.relayHost to a smarthost
+(Resend, SES, SendGrid, Mailgun, internal Postfix relay, etc.) for real
+deliverability.
+{{- else if .Values.outbound.relayHost }}
+
+Outbound mail relays through {{ .Values.outbound.relayHost }}:{{ .Values.outbound.relayPort }}{{ if not .Values.outbound.enabled }} (currently disabled — set outbound.enabled=true to dispatch){{ end }}.
+{{- end }}
+
+{{- if .Values.postgresql.enabled }}
+
+NOTE: postgresql.enabled=true deploys a single-replica PostgreSQL — fine for dev,
+but for production prefer an external managed database and set postgresql.enabled=false
+along with database.connectionString or database.existingSecret.
+{{- end }}

--- a/helm/relate-mail/templates/_helpers.tpl
+++ b/helm/relate-mail/templates/_helpers.tpl
@@ -1,0 +1,205 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "relate-mail.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified app name (release-name + chart-name unless overridden).
+*/}}
+{{- define "relate-mail.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Per-component fullname: e.g. <release>-relate-mail-api
+*/}}
+{{- define "relate-mail.componentFullname" -}}
+{{- $top := index . 0 -}}
+{{- $component := index . 1 -}}
+{{- printf "%s-%s" (include "relate-mail.fullname" $top) $component | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "relate-mail.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "relate-mail.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: relate-mail
+{{- end -}}
+
+{{/*
+Selector labels (release-scoped, no component).
+*/}}
+{{- define "relate-mail.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "relate-mail.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Component labels — call as: include "relate-mail.componentLabels" (list . "api")
+*/}}
+{{- define "relate-mail.componentLabels" -}}
+{{- $top := index . 0 -}}
+{{- $component := index . 1 -}}
+{{ include "relate-mail.labels" $top }}
+app.kubernetes.io/component: {{ $component }}
+{{- end -}}
+
+{{- define "relate-mail.componentSelectorLabels" -}}
+{{- $top := index . 0 -}}
+{{- $component := index . 1 -}}
+{{ include "relate-mail.selectorLabels" $top }}
+app.kubernetes.io/component: {{ $component }}
+{{- end -}}
+
+{{/*
+ServiceAccount name to use.
+*/}}
+{{- define "relate-mail.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "relate-mail.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the image reference for a given component.
+Usage: include "relate-mail.image" (dict "top" . "component" "api" "config" .Values.api)
+*/}}
+{{- define "relate-mail.image" -}}
+{{- $top := .top -}}
+{{- $component := .component -}}
+{{- $config := .config -}}
+{{- $repo := $config.image.repository -}}
+{{- if not $repo -}}
+{{- $repo = printf "%s/%s-%s" $top.Values.image.registry $top.Values.image.repository $component -}}
+{{- end -}}
+{{- $tag := default (default $top.Chart.AppVersion $top.Values.image.tag) $config.image.tag -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+
+{{/*
+Name of the Secret holding the database connection string.
+Always points at the chart-managed secret unless the user supplied an existingSecret.
+*/}}
+{{- define "relate-mail.dbSecretName" -}}
+{{- if .Values.database.existingSecret -}}
+{{- .Values.database.existingSecret -}}
+{{- else -}}
+{{- printf "%s-db" (include "relate-mail.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "relate-mail.dbSecretKey" -}}
+{{- if .Values.database.existingSecret -}}
+{{- .Values.database.existingSecretKey | default "connectionString" -}}
+{{- else -}}
+connectionString
+{{- end -}}
+{{- end -}}
+
+{{/*
+Build the database connection string when the chart manages the secret.
+Priority:
+  1) explicit database.connectionString
+  2) host/port/database/username/password (database.* values)
+  3) in-chart postgresql with its auth values (when postgresql.enabled)
+*/}}
+{{- define "relate-mail.dbConnectionString" -}}
+{{- if .Values.database.connectionString -}}
+{{- .Values.database.connectionString -}}
+{{- else if .Values.database.host -}}
+{{- printf "Host=%s;Port=%d;Database=%s;Username=%s;Password=%s" .Values.database.host (int .Values.database.port) .Values.database.database .Values.database.username .Values.database.password -}}
+{{- else if .Values.postgresql.enabled -}}
+{{- $host := printf "%s-postgresql" (include "relate-mail.fullname" .) -}}
+{{- printf "Host=%s;Port=%d;Database=%s;Username=%s;Password=%s" $host (int .Values.postgresql.service.port) .Values.postgresql.auth.database .Values.postgresql.auth.username .Values.postgresql.auth.password -}}
+{{- else -}}
+{{- fail "database.connectionString, database.existingSecret, database.host, or postgresql.enabled must be configured" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Internal API key secret name + key, mirroring the DB pattern.
+*/}}
+{{- define "relate-mail.internalSecretName" -}}
+{{- if .Values.internal.existingSecret -}}
+{{- .Values.internal.existingSecret -}}
+{{- else -}}
+{{- printf "%s-internal" (include "relate-mail.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "relate-mail.internalSecretKey" -}}
+{{- if .Values.internal.existingSecret -}}
+{{- .Values.internal.existingSecretKey | default "internalApiKey" -}}
+{{- else -}}
+internalApiKey
+{{- end -}}
+{{- end -}}
+
+{{/*
+Outbound relay password secret name/key.
+*/}}
+{{- define "relate-mail.outboundSecretName" -}}
+{{- if .Values.outbound.existingSecret -}}
+{{- .Values.outbound.existingSecret -}}
+{{- else -}}
+{{- printf "%s-outbound" (include "relate-mail.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "relate-mail.outboundSecretKey" -}}
+{{- if .Values.outbound.existingSecret -}}
+{{- .Values.outbound.existingSecretKey | default "relayPassword" -}}
+{{- else -}}
+relayPassword
+{{- end -}}
+{{- end -}}
+
+{{/*
+True when an outbound relay password is reachable (either inline or via existingSecret).
+*/}}
+{{- define "relate-mail.outboundHasPassword" -}}
+{{- if or .Values.outbound.relayPassword .Values.outbound.existingSecret -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Shared OutboundMail ConfigMap name.
+*/}}
+{{- define "relate-mail.outboundConfigName" -}}
+{{- printf "%s-outbound" (include "relate-mail.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Postgres password secret name/key.
+*/}}
+{{- define "relate-mail.pgSecretName" -}}
+{{- if .Values.postgresql.auth.existingSecret -}}
+{{- .Values.postgresql.auth.existingSecret -}}
+{{- else -}}
+{{- printf "%s-postgresql" (include "relate-mail.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "relate-mail.pgSecretKey" -}}
+{{- if .Values.postgresql.auth.existingSecret -}}
+{{- .Values.postgresql.auth.existingSecretKey | default "password" -}}
+{{- else -}}
+password
+{{- end -}}
+{{- end -}}

--- a/helm/relate-mail/templates/api-deployment.yaml
+++ b/helm/relate-mail/templates/api-deployment.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.api.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "relate-mail.componentFullname" (list . "api") }}
+  labels:
+    {{- include "relate-mail.componentLabels" (list . "api") | nindent 4 }}
+spec:
+  replicas: {{ .Values.api.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "relate-mail.componentSelectorLabels" (list . "api") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "relate-mail.componentSelectorLabels" (list . "api") | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "relate-mail.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: api
+          image: {{ include "relate-mail.image" (dict "top" . "component" "api" "config" .Values.api) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.api.service.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "relate-mail.outboundConfigName" . }}
+          env:
+            - name: ASPNETCORE_URLS
+              value: {{ printf "http://+:%d" (int .Values.api.service.port) | quote }}
+            - name: ConnectionStrings__DefaultConnection
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "relate-mail.dbSecretName" . }}
+                  key: {{ include "relate-mail.dbSecretKey" . }}
+            {{- if .Values.oidc.authority }}
+            - name: Oidc__Authority
+              value: {{ .Values.oidc.authority | quote }}
+            {{- end }}
+            {{- if .Values.oidc.audience }}
+            - name: Oidc__Audience
+              value: {{ .Values.oidc.audience | quote }}
+            {{- end }}
+            {{- if .Values.cors.allowedOrigins }}
+            - name: CORS_ALLOWED_ORIGINS
+              value: {{ .Values.cors.allowedOrigins | quote }}
+            {{- end }}
+            {{- if eq (include "relate-mail.outboundHasPassword" .) "true" }}
+            - name: OutboundMail__RelayPassword
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "relate-mail.outboundSecretName" . }}
+                  key: {{ include "relate-mail.outboundSecretKey" . }}
+            {{- end }}
+            {{- with .Values.api.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/relate-mail/templates/api-ingress.yaml
+++ b/helm/relate-mail/templates/api-ingress.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.api.enabled .Values.api.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "relate-mail.componentFullname" (list . "api") }}
+  labels:
+    {{- include "relate-mail.componentLabels" (list . "api") | nindent 4 }}
+  {{- with .Values.api.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.api.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.api.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.api.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "relate-mail.componentFullname" (list $ "api") }}
+                port:
+                  number: {{ $.Values.api.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/relate-mail/templates/api-service.yaml
+++ b/helm/relate-mail/templates/api-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.api.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "relate-mail.componentFullname" (list . "api") }}
+  labels:
+    {{- include "relate-mail.componentLabels" (list . "api") | nindent 4 }}
+spec:
+  type: {{ .Values.api.service.type }}
+  selector:
+    {{- include "relate-mail.componentSelectorLabels" (list . "api") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.api.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/helm/relate-mail/templates/imap-deployment.yaml
+++ b/helm/relate-mail/templates/imap-deployment.yaml
@@ -1,0 +1,107 @@
+{{- if .Values.imap.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "relate-mail.componentFullname" (list . "imap") }}
+  labels:
+    {{- include "relate-mail.componentLabels" (list . "imap") | nindent 4 }}
+spec:
+  replicas: {{ .Values.imap.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "relate-mail.componentSelectorLabels" (list . "imap") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "relate-mail.componentSelectorLabels" (list . "imap") | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "relate-mail.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: imap
+          image: {{ include "relate-mail.image" (dict "top" . "component" "imap" "config" .Values.imap) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: imap
+              containerPort: {{ .Values.imap.port }}
+              protocol: TCP
+            - name: imaps
+              containerPort: {{ .Values.imap.securePort }}
+              protocol: TCP
+            - name: health
+              containerPort: {{ .Values.imap.healthPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "relate-mail.outboundConfigName" . }}
+          env:
+            - name: ConnectionStrings__DefaultConnection
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "relate-mail.dbSecretName" . }}
+                  key: {{ include "relate-mail.dbSecretKey" . }}
+            - name: Imap__ServerName
+              value: {{ .Values.imap.serverName | quote }}
+            - name: Imap__Port
+              value: {{ .Values.imap.port | quote }}
+            - name: Imap__SecurePort
+              value: {{ .Values.imap.securePort | quote }}
+            - name: Imap__RequireAuthentication
+              value: {{ .Values.imap.requireAuthentication | quote }}
+            - name: HealthCheck__Url
+              value: {{ printf "http://+:%d" (int .Values.imap.healthPort) | quote }}
+            {{- if eq (include "relate-mail.outboundHasPassword" .) "true" }}
+            - name: OutboundMail__RelayPassword
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "relate-mail.outboundSecretName" . }}
+                  key: {{ include "relate-mail.outboundSecretKey" . }}
+            {{- end }}
+            {{- with .Values.imap.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.imap.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/relate-mail/templates/imap-service.yaml
+++ b/helm/relate-mail/templates/imap-service.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.imap.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "relate-mail.componentFullname" (list . "imap") }}
+  labels:
+    {{- include "relate-mail.componentLabels" (list . "imap") | nindent 4 }}
+  {{- with .Values.imap.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.imap.service.type }}
+  {{- if and (eq .Values.imap.service.type "LoadBalancer") .Values.imap.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.imap.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.imap.service.type "LoadBalancer") .Values.imap.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.imap.service.externalTrafficPolicy }}
+  {{- end }}
+  selector:
+    {{- include "relate-mail.componentSelectorLabels" (list . "imap") | nindent 4 }}
+  ports:
+    - name: imap
+      port: {{ .Values.imap.port }}
+      targetPort: imap
+      protocol: TCP
+    - name: imaps
+      port: {{ .Values.imap.securePort }}
+      targetPort: imaps
+      protocol: TCP
+{{- end }}

--- a/helm/relate-mail/templates/outbound-configmap.yaml
+++ b/helm/relate-mail/templates/outbound-configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "relate-mail.outboundConfigName" . }}
+  labels:
+    {{- include "relate-mail.labels" . | nindent 4 }}
+data:
+  OutboundMail__Enabled: {{ .Values.outbound.enabled | quote }}
+  OutboundMail__RelayHost: {{ .Values.outbound.relayHost | quote }}
+  OutboundMail__RelayPort: {{ .Values.outbound.relayPort | quote }}
+  OutboundMail__RelayUseTls: {{ .Values.outbound.relayUseTls | quote }}
+  OutboundMail__RelayUsername: {{ .Values.outbound.relayUsername | quote }}
+  OutboundMail__SenderDomain: {{ .Values.outbound.senderDomain | quote }}
+  OutboundMail__MaxConcurrency: {{ .Values.outbound.maxConcurrency | quote }}
+  OutboundMail__MaxRetries: {{ .Values.outbound.maxRetries | quote }}
+  OutboundMail__RetryBaseDelaySeconds: {{ .Values.outbound.retryBaseDelaySeconds | quote }}
+  OutboundMail__QueuePollingIntervalSeconds: {{ .Values.outbound.queuePollingIntervalSeconds | quote }}
+  OutboundMail__SmtpTimeoutSeconds: {{ .Values.outbound.smtpTimeoutSeconds | quote }}

--- a/helm/relate-mail/templates/pop3-deployment.yaml
+++ b/helm/relate-mail/templates/pop3-deployment.yaml
@@ -1,0 +1,107 @@
+{{- if .Values.pop3.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "relate-mail.componentFullname" (list . "pop3") }}
+  labels:
+    {{- include "relate-mail.componentLabels" (list . "pop3") | nindent 4 }}
+spec:
+  replicas: {{ .Values.pop3.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "relate-mail.componentSelectorLabels" (list . "pop3") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "relate-mail.componentSelectorLabels" (list . "pop3") | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "relate-mail.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: pop3
+          image: {{ include "relate-mail.image" (dict "top" . "component" "pop3" "config" .Values.pop3) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: pop3
+              containerPort: {{ .Values.pop3.port }}
+              protocol: TCP
+            - name: pop3s
+              containerPort: {{ .Values.pop3.securePort }}
+              protocol: TCP
+            - name: health
+              containerPort: {{ .Values.pop3.healthPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "relate-mail.outboundConfigName" . }}
+          env:
+            - name: ConnectionStrings__DefaultConnection
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "relate-mail.dbSecretName" . }}
+                  key: {{ include "relate-mail.dbSecretKey" . }}
+            - name: Pop3__ServerName
+              value: {{ .Values.pop3.serverName | quote }}
+            - name: Pop3__Port
+              value: {{ .Values.pop3.port | quote }}
+            - name: Pop3__SecurePort
+              value: {{ .Values.pop3.securePort | quote }}
+            - name: Pop3__RequireAuthentication
+              value: {{ .Values.pop3.requireAuthentication | quote }}
+            - name: HealthCheck__Url
+              value: {{ printf "http://+:%d" (int .Values.pop3.healthPort) | quote }}
+            {{- if eq (include "relate-mail.outboundHasPassword" .) "true" }}
+            - name: OutboundMail__RelayPassword
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "relate-mail.outboundSecretName" . }}
+                  key: {{ include "relate-mail.outboundSecretKey" . }}
+            {{- end }}
+            {{- with .Values.pop3.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.pop3.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/relate-mail/templates/pop3-service.yaml
+++ b/helm/relate-mail/templates/pop3-service.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.pop3.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "relate-mail.componentFullname" (list . "pop3") }}
+  labels:
+    {{- include "relate-mail.componentLabels" (list . "pop3") | nindent 4 }}
+  {{- with .Values.pop3.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.pop3.service.type }}
+  {{- if and (eq .Values.pop3.service.type "LoadBalancer") .Values.pop3.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.pop3.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.pop3.service.type "LoadBalancer") .Values.pop3.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.pop3.service.externalTrafficPolicy }}
+  {{- end }}
+  selector:
+    {{- include "relate-mail.componentSelectorLabels" (list . "pop3") | nindent 4 }}
+  ports:
+    - name: pop3
+      port: {{ .Values.pop3.port }}
+      targetPort: pop3
+      protocol: TCP
+    - name: pop3s
+      port: {{ .Values.pop3.securePort }}
+      targetPort: pop3s
+      protocol: TCP
+{{- end }}

--- a/helm/relate-mail/templates/postgres-secret.yaml
+++ b/helm/relate-mail/templates/postgres-secret.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.postgresql.enabled (not .Values.postgresql.auth.existingSecret) }}
+{{- if not .Values.postgresql.auth.password }}
+{{- fail "postgresql.auth.password is required when postgresql.enabled=true and postgresql.auth.existingSecret is empty" }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-postgresql" (include "relate-mail.fullname" .) }}
+  labels:
+    {{- include "relate-mail.componentLabels" (list . "postgresql") | nindent 4 }}
+type: Opaque
+stringData:
+  password: {{ .Values.postgresql.auth.password | quote }}
+{{- end }}

--- a/helm/relate-mail/templates/postgres-service.yaml
+++ b/helm/relate-mail/templates/postgres-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-postgresql" (include "relate-mail.fullname" .) }}
+  labels:
+    {{- include "relate-mail.componentLabels" (list . "postgresql") | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    {{- include "relate-mail.componentSelectorLabels" (list . "postgresql") | nindent 4 }}
+  ports:
+    - name: postgresql
+      port: {{ .Values.postgresql.service.port }}
+      targetPort: postgresql
+      protocol: TCP
+{{- end }}

--- a/helm/relate-mail/templates/postgres-statefulset.yaml
+++ b/helm/relate-mail/templates/postgres-statefulset.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ printf "%s-postgresql" (include "relate-mail.fullname" .) }}
+  labels:
+    {{- include "relate-mail.componentLabels" (list . "postgresql") | nindent 4 }}
+spec:
+  serviceName: {{ printf "%s-postgresql" (include "relate-mail.fullname" .) }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "relate-mail.componentSelectorLabels" (list . "postgresql") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "relate-mail.componentSelectorLabels" (list . "postgresql") | nindent 8 }}
+    spec:
+      securityContext:
+        fsGroup: 999
+      containers:
+        - name: postgresql
+          image: {{ printf "%s:%s" .Values.postgresql.image.repository .Values.postgresql.image.tag | quote }}
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          ports:
+            - name: postgresql
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresql.auth.username | quote }}
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.auth.database | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "relate-mail.pgSecretName" . }}
+                  key: {{ include "relate-mail.pgSecretKey" . }}
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "{{ .Values.postgresql.auth.username }}", "-d", "{{ .Values.postgresql.auth.database }}"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "{{ .Values.postgresql.auth.username }}", "-d", "{{ .Values.postgresql.auth.database }}"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      {{- if not .Values.postgresql.persistence.enabled }}
+      volumes:
+        - name: data
+          emptyDir: {}
+      {{- end }}
+  {{- if .Values.postgresql.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "relate-mail.componentSelectorLabels" (list . "postgresql") | nindent 10 }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.postgresql.persistence.accessModes | nindent 10 }}
+        {{- with .Values.postgresql.persistence.storageClass }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.persistence.size }}
+  {{- end }}
+{{- end }}

--- a/helm/relate-mail/templates/secret-db.yaml
+++ b/helm/relate-mail/templates/secret-db.yaml
@@ -1,0 +1,11 @@
+{{- if not .Values.database.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-db" (include "relate-mail.fullname" .) }}
+  labels:
+    {{- include "relate-mail.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  connectionString: {{ include "relate-mail.dbConnectionString" . | quote }}
+{{- end }}

--- a/helm/relate-mail/templates/secret-internal.yaml
+++ b/helm/relate-mail/templates/secret-internal.yaml
@@ -1,0 +1,11 @@
+{{- if and (not .Values.internal.existingSecret) .Values.internal.apiKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-internal" (include "relate-mail.fullname" .) }}
+  labels:
+    {{- include "relate-mail.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  internalApiKey: {{ .Values.internal.apiKey | quote }}
+{{- end }}

--- a/helm/relate-mail/templates/secret-outbound.yaml
+++ b/helm/relate-mail/templates/secret-outbound.yaml
@@ -1,0 +1,11 @@
+{{- if and (not .Values.outbound.existingSecret) .Values.outbound.relayPassword }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-outbound" (include "relate-mail.fullname" .) }}
+  labels:
+    {{- include "relate-mail.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  relayPassword: {{ .Values.outbound.relayPassword | quote }}
+{{- end }}

--- a/helm/relate-mail/templates/serviceaccount.yaml
+++ b/helm/relate-mail/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "relate-mail.serviceAccountName" . }}
+  labels:
+    {{- include "relate-mail.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/relate-mail/templates/smtp-deployment.yaml
+++ b/helm/relate-mail/templates/smtp-deployment.yaml
@@ -1,0 +1,133 @@
+{{- if .Values.smtp.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "relate-mail.componentFullname" (list . "smtp") }}
+  labels:
+    {{- include "relate-mail.componentLabels" (list . "smtp") | nindent 4 }}
+spec:
+  replicas: {{ .Values.smtp.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "relate-mail.componentSelectorLabels" (list . "smtp") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "relate-mail.componentSelectorLabels" (list . "smtp") | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "relate-mail.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: smtp
+          image: {{ include "relate-mail.image" (dict "top" . "component" "smtp" "config" .Values.smtp) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: submission
+              containerPort: {{ .Values.smtp.submissionPort }}
+              protocol: TCP
+            - name: implicit-tls
+              containerPort: {{ .Values.smtp.implicitTlsPort }}
+              protocol: TCP
+            {{- if .Values.smtp.mx.enabled }}
+            - name: mx
+              containerPort: {{ .Values.smtp.mx.port }}
+              protocol: TCP
+            {{- end }}
+            - name: health
+              containerPort: {{ .Values.smtp.healthPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "relate-mail.outboundConfigName" . }}
+          env:
+            - name: ConnectionStrings__DefaultConnection
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "relate-mail.dbSecretName" . }}
+                  key: {{ include "relate-mail.dbSecretKey" . }}
+            - name: Smtp__ServerName
+              value: {{ .Values.smtp.serverName | quote }}
+            - name: Smtp__Port
+              value: {{ .Values.smtp.submissionPort | quote }}
+            - name: Smtp__SecurePort
+              value: {{ .Values.smtp.implicitTlsPort | quote }}
+            - name: Smtp__RequireAuthentication
+              value: {{ .Values.smtp.requireAuthentication | quote }}
+            - name: Smtp__Mx__Enabled
+              value: {{ .Values.smtp.mx.enabled | quote }}
+            {{- if .Values.smtp.mx.enabled }}
+            - name: Smtp__Mx__Port
+              value: {{ .Values.smtp.mx.port | quote }}
+            - name: Smtp__Mx__ValidateRecipients
+              value: {{ .Values.smtp.mx.validateRecipients | quote }}
+            {{- range $i, $domain := .Values.smtp.mx.hostedDomains }}
+            - name: {{ printf "Smtp__Mx__HostedDomains__%d" $i | quote }}
+              value: {{ $domain | quote }}
+            {{- end }}
+            {{- end }}
+            - name: Api__BaseUrl
+              value: {{ printf "http://%s:%d" (include "relate-mail.componentFullname" (list . "api")) (int .Values.api.service.port) | quote }}
+            {{- if or .Values.internal.apiKey .Values.internal.existingSecret }}
+            - name: Internal__ApiKey
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "relate-mail.internalSecretName" . }}
+                  key: {{ include "relate-mail.internalSecretKey" . }}
+            {{- end }}
+            - name: HealthCheck__Url
+              value: {{ printf "http://+:%d" (int .Values.smtp.healthPort) | quote }}
+            {{- if eq (include "relate-mail.outboundHasPassword" .) "true" }}
+            - name: OutboundMail__RelayPassword
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "relate-mail.outboundSecretName" . }}
+                  key: {{ include "relate-mail.outboundSecretKey" . }}
+            {{- end }}
+            {{- with .Values.smtp.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.smtp.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/relate-mail/templates/smtp-service.yaml
+++ b/helm/relate-mail/templates/smtp-service.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.smtp.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "relate-mail.componentFullname" (list . "smtp") }}
+  labels:
+    {{- include "relate-mail.componentLabels" (list . "smtp") | nindent 4 }}
+  {{- with .Values.smtp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.smtp.service.type }}
+  {{- if and (eq .Values.smtp.service.type "LoadBalancer") .Values.smtp.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.smtp.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.smtp.service.type "LoadBalancer") .Values.smtp.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.smtp.service.externalTrafficPolicy }}
+  {{- end }}
+  selector:
+    {{- include "relate-mail.componentSelectorLabels" (list . "smtp") | nindent 4 }}
+  ports:
+    - name: submission
+      port: {{ .Values.smtp.submissionPort }}
+      targetPort: submission
+      protocol: TCP
+    - name: implicit-tls
+      port: {{ .Values.smtp.implicitTlsPort }}
+      targetPort: implicit-tls
+      protocol: TCP
+    {{- if .Values.smtp.mx.enabled }}
+    - name: mx
+      port: {{ .Values.smtp.mx.port }}
+      targetPort: mx
+      protocol: TCP
+    {{- end }}
+{{- end }}

--- a/helm/relate-mail/templates/web-deployment.yaml
+++ b/helm/relate-mail/templates/web-deployment.yaml
@@ -1,0 +1,96 @@
+{{- if .Values.web.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "relate-mail.componentFullname" (list . "web") }}
+  labels:
+    {{- include "relate-mail.componentLabels" (list . "web") | nindent 4 }}
+spec:
+  replicas: {{ .Values.web.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "relate-mail.componentSelectorLabels" (list . "web") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "relate-mail.componentSelectorLabels" (list . "web") | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "relate-mail.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: web
+          image: {{ include "relate-mail.image" (dict "top" . "component" "web" "config" .Values.web) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.web.containerPort }}
+              protocol: TCP
+          env:
+            - name: API_URL
+              value: {{ .Values.web.apiUrl | quote }}
+            {{- if .Values.oidc.authority }}
+            - name: OIDC_AUTHORITY
+              value: {{ .Values.oidc.authority | quote }}
+            {{- end }}
+            {{- if .Values.web.oidc.clientId }}
+            - name: OIDC_CLIENT_ID
+              value: {{ .Values.web.oidc.clientId | quote }}
+            {{- end }}
+            {{- if .Values.web.oidc.redirectUri }}
+            - name: OIDC_REDIRECT_URI
+              value: {{ .Values.web.oidc.redirectUri | quote }}
+            {{- end }}
+            {{- if .Values.web.oidc.scope }}
+            - name: OIDC_SCOPE
+              value: {{ .Values.web.oidc.scope | quote }}
+            {{- end }}
+            {{- with .Values.web.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.web.healthPath }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.web.healthPath }}
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.web.healthPath }}
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- end }}
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/relate-mail/templates/web-ingress.yaml
+++ b/helm/relate-mail/templates/web-ingress.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.web.enabled .Values.web.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "relate-mail.componentFullname" (list . "web") }}
+  labels:
+    {{- include "relate-mail.componentLabels" (list . "web") | nindent 4 }}
+  {{- with .Values.web.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.web.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.web.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.web.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "relate-mail.componentFullname" (list $ "web") }}
+                port:
+                  number: {{ $.Values.web.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/relate-mail/templates/web-service.yaml
+++ b/helm/relate-mail/templates/web-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.web.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "relate-mail.componentFullname" (list . "web") }}
+  labels:
+    {{- include "relate-mail.componentLabels" (list . "web") | nindent 4 }}
+spec:
+  type: {{ .Values.web.service.type }}
+  selector:
+    {{- include "relate-mail.componentSelectorLabels" (list . "web") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.web.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/helm/relate-mail/values.yaml
+++ b/helm/relate-mail/values.yaml
@@ -1,0 +1,291 @@
+# Default values for relate-mail.
+# Override with --set or a custom values.yaml.
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Image settings shared by all four service images (api, smtp, pop3, imap).
+# Each component below can override `image.repository` and `image.tag`.
+image:
+  registry: ghcr.io
+  repository: four-robots/relate-mail
+  tag: ""              # defaults to .Chart.AppVersion when empty
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+# - name: ghcr-creds
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+podAnnotations: {}
+podLabels: {}
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop: ["ALL"]
+
+# Database connection.
+# If postgresql.enabled=true, this chart deploys a single-node PostgreSQL
+# and constructs the connection string from postgresql.* values.
+# Otherwise, set database.existingSecret OR database.connectionString
+# (or the host/user/password fields below) to point at an external DB.
+database:
+  # Plaintext connection string. Used only when set and no existingSecret is provided.
+  connectionString: ""
+  # Reference an existing Secret with key `connectionString`.
+  existingSecret: ""
+  existingSecretKey: connectionString
+  # Used to build a connection string when both connectionString and existingSecret are empty.
+  host: ""
+  port: 5432
+  database: relate_mail
+  username: postgres
+  password: ""
+
+# In-chart PostgreSQL (single replica, suitable for dev / small deployments).
+# For production, prefer an external managed Postgres and set this to false.
+postgresql:
+  enabled: true
+  image:
+    repository: postgres
+    tag: "16-alpine"
+    pullPolicy: IfNotPresent
+  auth:
+    username: postgres
+    password: ""               # required when postgresql.enabled=true and existingSecret is empty
+    database: relate_mail
+    existingSecret: ""         # Secret with key `password`
+    existingSecretKey: password
+  service:
+    port: 5432
+  persistence:
+    enabled: true
+    storageClass: ""
+    size: 10Gi
+    accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+# OIDC (optional). Leave authority empty to run the API in unauthenticated dev mode.
+oidc:
+  authority: ""
+  audience: ""
+
+# Internal API key used by the SMTP host to call the API's internal endpoints.
+# Provide it inline OR via an existing Secret with key `internalApiKey`.
+internal:
+  apiKey: ""
+  existingSecret: ""
+  existingSecretKey: internalApiKey
+
+# CORS for the API (comma-separated origins).
+cors:
+  allowedOrigins: ""
+
+# Outbound mail delivery.
+# The DeliveryQueueProcessor runs in every host that calls AddInfrastructure
+# (api, smtp, pop3, imap) — so these settings are pushed to all four
+# deployments via a shared ConfigMap. Set `enabled: true` to actually
+# dispatch queued mail; leave it false to keep mail queued.
+#
+# When `relayHost` is set, mail is relayed through that smarthost (Resend,
+# SES, SendGrid, Mailgun, an internal Postfix relay, etc.). When empty,
+# the SMTP daemon attempts direct-to-MX delivery, which is unlikely to be
+# accepted from most cluster egress IPs.
+outbound:
+  enabled: false
+  relayHost: ""
+  relayPort: 587
+  relayUseTls: true
+  relayUsername: ""
+  # Provide the relay password inline OR via an existing Secret with key `relayPassword`.
+  relayPassword: ""
+  existingSecret: ""
+  existingSecretKey: relayPassword
+  # The MAIL FROM domain announced to the relay (also used in HELO/EHLO).
+  senderDomain: ""
+  maxConcurrency: 5
+  maxRetries: 10
+  retryBaseDelaySeconds: 60
+  queuePollingIntervalSeconds: 15
+  smtpTimeoutSeconds: 30
+
+# REST API workload.
+api:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: ""             # falls back to {{ image.registry }}/{{ image.repository }}-api
+    tag: ""
+  service:
+    type: ClusterIP
+    port: 8080
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  env: []                      # extra env vars: [{name: FOO, value: bar}, ...]
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: relate-mail.local
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+    # - secretName: relate-mail-tls
+    #   hosts:
+    #     - relate-mail.local
+
+# SMTP submission + (optional) MX workload.
+smtp:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: ""             # falls back to {{ image.registry }}/{{ image.repository }}-smtp
+    tag: ""
+  serverName: smtp.example.com
+  requireAuthentication: true
+  submissionPort: 587
+  implicitTlsPort: 465
+  healthPort: 8081
+  mx:
+    enabled: false
+    port: 25
+    hostedDomains: []          # e.g. ["example.com"]
+    validateRecipients: true
+  service:
+    type: LoadBalancer
+    annotations: {}
+    externalTrafficPolicy: Local
+    loadBalancerIP: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  env: []
+
+pop3:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: ""             # falls back to {{ image.registry }}/{{ image.repository }}-pop3
+    tag: ""
+  serverName: pop3.example.com
+  requireAuthentication: true
+  port: 110
+  securePort: 995
+  healthPort: 8082
+  service:
+    type: LoadBalancer
+    annotations: {}
+    externalTrafficPolicy: Local
+    loadBalancerIP: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  env: []
+
+imap:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: ""             # falls back to {{ image.registry }}/{{ image.repository }}-imap
+    tag: ""
+  serverName: imap.example.com
+  requireAuthentication: true
+  port: 143
+  securePort: 993
+  healthPort: 8083
+  service:
+    type: LoadBalancer
+    annotations: {}
+    externalTrafficPolicy: Local
+    loadBalancerIP: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  env: []
+
+# Web SPA frontend.
+# Disabled by default — the project does not yet publish a `relate-mail-web`
+# image. Once it does, set `web.enabled=true` (and override the image if
+# the published name differs from the convention below).
+#
+# Runtime config (apiUrl, OIDC client) is passed as env vars; the image is
+# expected to render `config.json` from these at container startup. See
+# docker/.env.example in the project for the naming convention.
+web:
+  enabled: false
+  replicaCount: 1
+  image:
+    repository: ""             # falls back to {{ image.registry }}/{{ image.repository }}-web
+    tag: ""
+  service:
+    type: ClusterIP
+    port: 8080
+  containerPort: 8080
+  # Path the SPA uses to reach the API. Relative paths assume the same
+  # ingress also routes that prefix to the api Service.
+  apiUrl: /api
+  oidc:
+    clientId: ""
+    redirectUri: ""
+    scope: "openid profile email"
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  # HTTP path used for liveness/readiness probes. Empty disables probes.
+  healthPath: /
+  env: []
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: relate-mail.local
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+    # - secretName: relate-mail-web-tls
+    #   hosts:
+    #     - relate-mail.local
+
+# Scheduling
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Summary
- Adds a Helm chart at `helm/relate-mail/` covering API, SMTP, POP3, IMAP, an optional in-chart PostgreSQL, and a disabled-by-default web SPA pod (ready for when `relate-mail-web` ships).
- Each protocol host is its own Deployment + Service so SMTP/POP3/IMAP ports can be exposed via separate `LoadBalancer`s while the HTTP API stays internal behind an `Ingress`.
- Wires outbound smarthost relay (`OutboundMail__*`) through a shared `ConfigMap` + `Secret` so users can route mail through Resend / SES / SendGrid / Mailgun / Postfix instead of relying on direct-to-MX delivery from cluster egress IPs.

## Test plan
- [ ] `helm lint helm/relate-mail --set postgresql.auth.password=devpass` passes
- [ ] `helm template demo helm/relate-mail --set postgresql.auth.password=devpass` renders cleanly
- [ ] External DB path: `--set postgresql.enabled=false --set database.connectionString=...`
- [ ] External DB via existing secret: `--set postgresql.enabled=false --set database.existingSecret=my-db --set database.existingSecretKey=conn`
- [ ] Outbound relay injects `OutboundMail__RelayPassword` into all four deployments when set
- [ ] `web.enabled=true` renders Deployment + Service (+ Ingress when `web.ingress.enabled=true`)
- [ ] `helm install --dry-run` prints the relay-host warning when `outbound.enabled=true` and `outbound.relayHost` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)