### PR TITLE
feat(web,helm): publish web image and add k3s probes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,6 +450,8 @@ jobs:
             target: pop3
           - name: imap
             target: imap
+          - name: web
+            target: web
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,6 +47,10 @@ jobs:
             context: .
             dockerfile: ./api/Dockerfile
             target: imap
+          - name: web
+            context: .
+            dockerfile: ./api/Dockerfile
+            target: web
 
     steps:
       - name: Checkout repository
@@ -125,3 +129,4 @@ jobs:
           echo "- ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-smtp" >> $GITHUB_STEP_SUMMARY
           echo "- ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-pop3" >> $GITHUB_STEP_SUMMARY
           echo "- ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-imap" >> $GITHUB_STEP_SUMMARY
+          echo "- ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-web" >> $GITHUB_STEP_SUMMARY

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -119,3 +119,35 @@ LABEL org.opencontainers.image.source="https://github.com/four-robots/relate-mai
 EXPOSE 143 993 8083
 ENV HealthCheck__Url=http://+:8083
 ENTRYPOINT ["dotnet", "Relate.Smtp.ImapHost.dll"]
+
+# Web (SPA) runtime image — separate from the API image so it can roll independently.
+# nginxinc/nginx-unprivileged runs as UID 101 and listens on 8080 by default, so no
+# privileged-port handling is needed in k8s/k3s.
+FROM nginxinc/nginx-unprivileged:1.27-alpine@sha256:65e3e85dbaed8ba248841d9d58a899b6197106c23cb0ff1a132b7bfe0547e4c0 AS web
+
+# Templates listed under /etc/nginx/templates/*.template are envsubst'd into
+# /etc/nginx/conf.d/ on container start by the base image. We use that to inject
+# ${API_BACKEND} into the proxy_pass directive.
+COPY web/nginx.conf /etc/nginx/templates/default.conf.template
+
+# Hooks under /docker-entrypoint.d/ are executed before nginx starts.
+COPY web/docker-entrypoint.sh /docker-entrypoint.d/30-generate-config-json.sh
+
+# Static assets
+COPY --from=node-build /src/web/dist /usr/share/nginx/html
+
+# Defaults; override in k8s. API_BACKEND points the /api proxy at the in-cluster
+# API service. The OIDC_* vars are baked into config.json by the entrypoint hook.
+ENV API_BACKEND=http://api:8080 \
+    OIDC_AUTHORITY="" \
+    OIDC_CLIENT_ID="" \
+    OIDC_REDIRECT_URI="" \
+    OIDC_SCOPE="openid profile email"
+
+# OCI Labels
+LABEL org.opencontainers.image.title="Relate Mail Web"
+LABEL org.opencontainers.image.description="React + Vite SPA frontend for Relate Mail, served by nginx"
+LABEL org.opencontainers.image.vendor="Relate Mail"
+LABEL org.opencontainers.image.source="https://github.com/four-robots/relate-mail"
+
+EXPOSE 8080

--- a/helm/relate-mail/README.md
+++ b/helm/relate-mail/README.md
@@ -159,17 +159,14 @@ direct MX delivery — fine for testing, generally not for production.
 
 ## Web SPA
 
-The `web` component is **disabled by default** because the project does
-not yet publish a `relate-mail-web` image. Once it does, enable it as a
-separate pod so it can roll independently of the API/protocol hosts:
+The `web` component is **disabled by default** but the image
+(`ghcr.io/four-robots/relate-mail-web`) is published from the same release
+pipeline as api/smtp/pop3/imap. Enable it as a separate pod so it can roll
+independently:
 
 ```yaml
 web:
   enabled: true
-  image:
-    # falls back to ghcr.io/four-robots/relate-mail-web:<chart appVersion>
-    tag: "1.2.3"
-  apiUrl: /api
   oidc:
     clientId: relate-mail-web
     redirectUri: https://relate.example.com
@@ -183,17 +180,23 @@ web:
             pathType: Prefix
 ```
 
-`OIDC_AUTHORITY` is shared with the API via the top-level `oidc.authority`.
-`API_URL`, `OIDC_CLIENT_ID`, `OIDC_REDIRECT_URI`, and `OIDC_SCOPE` are passed
-as env vars; the image is expected to render them into `config.json` at
-container startup (see `docker/.env.example` in the project).
+How config flows:
 
-If you want the SPA at `/` and the API at `/api` on the same host, point
-`web.ingress` at the user-facing host and add a path-based rule that
-forwards `/api` to the API Service — most ingress controllers handle this
-with a single Ingress resource (use `nginx.ingress.kubernetes.io/rewrite-target`
-or your controller's equivalent), or split it across two Ingress resources
-on the same host.
+- `OIDC_AUTHORITY`, `OIDC_CLIENT_ID`, `OIDC_REDIRECT_URI`, `OIDC_SCOPE` and
+  `API_URL` are passed as env vars; the image's startup hook renders them
+  into `/usr/share/nginx/html/config/config.json` before nginx launches.
+  `OIDC_AUTHORITY` defaults to the chart-wide `oidc.authority`.
+- The image's embedded nginx reverse-proxies `/api` to whatever
+  `API_BACKEND` points at. The chart automatically sets that to the
+  in-cluster api Service URL, so a single ingress fronting the web pod
+  serves the SPA at `/` and forwards `/api` to the API without needing a
+  second ingress rule. Override with `web.apiBackend` if you want to point
+  at a different API.
+
+If you'd rather route `/api` to the API service via your ingress controller
+instead of through the SPA pod, set `web.apiUrl: /api` and add an Ingress
+rule that backends `/api` at the api Service (path-based fan-out with
+`nginx.ingress.kubernetes.io/rewrite-target` or your controller's equivalent).
 
 ## Ingress
 

--- a/helm/relate-mail/templates/api-deployment.yaml
+++ b/helm/relate-mail/templates/api-deployment.yaml
@@ -72,11 +72,17 @@ spec:
             {{- with .Values.api.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 5
+            failureThreshold: 30
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: /healthz
               port: http
-            initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
@@ -84,7 +90,6 @@ spec:
             httpGet:
               path: /healthz
               port: http
-            initialDelaySeconds: 20
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3

--- a/helm/relate-mail/templates/imap-deployment.yaml
+++ b/helm/relate-mail/templates/imap-deployment.yaml
@@ -74,11 +74,17 @@ spec:
             {{- with .Values.imap.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            periodSeconds: 5
+            failureThreshold: 30
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: /healthz
               port: health
-            initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
@@ -86,7 +92,6 @@ spec:
             httpGet:
               path: /healthz
               port: health
-            initialDelaySeconds: 20
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3

--- a/helm/relate-mail/templates/pop3-deployment.yaml
+++ b/helm/relate-mail/templates/pop3-deployment.yaml
@@ -74,11 +74,17 @@ spec:
             {{- with .Values.pop3.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            periodSeconds: 5
+            failureThreshold: 30
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: /healthz
               port: health
-            initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
@@ -86,7 +92,6 @@ spec:
             httpGet:
               path: /healthz
               port: health
-            initialDelaySeconds: 20
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3

--- a/helm/relate-mail/templates/smtp-deployment.yaml
+++ b/helm/relate-mail/templates/smtp-deployment.yaml
@@ -100,11 +100,17 @@ spec:
             {{- with .Values.smtp.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            periodSeconds: 5
+            failureThreshold: 30
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: /healthz
               port: health
-            initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
@@ -112,7 +118,6 @@ spec:
             httpGet:
               path: /healthz
               port: health
-            initialDelaySeconds: 20
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3

--- a/helm/relate-mail/templates/web-deployment.yaml
+++ b/helm/relate-mail/templates/web-deployment.yaml
@@ -42,6 +42,8 @@ spec:
           env:
             - name: API_URL
               value: {{ .Values.web.apiUrl | quote }}
+            - name: API_BACKEND
+              value: {{ default (printf "http://%s:%d" (include "relate-mail.componentFullname" (list . "api")) (int .Values.api.service.port)) .Values.web.apiBackend | quote }}
             {{- if .Values.oidc.authority }}
             - name: OIDC_AUTHORITY
               value: {{ .Values.oidc.authority | quote }}
@@ -62,11 +64,17 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- if .Values.web.healthPath }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.web.healthPath }}
+              port: http
+            periodSeconds: 2
+            failureThreshold: 15
+            timeoutSeconds: 2
           readinessProbe:
             httpGet:
               path: {{ .Values.web.healthPath }}
               port: http
-            initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
@@ -74,7 +82,6 @@ spec:
             httpGet:
               path: {{ .Values.web.healthPath }}
               port: http
-            initialDelaySeconds: 20
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3

--- a/helm/relate-mail/values.yaml
+++ b/helm/relate-mail/values.yaml
@@ -237,13 +237,12 @@ imap:
   env: []
 
 # Web SPA frontend.
-# Disabled by default — the project does not yet publish a `relate-mail-web`
-# image. Once it does, set `web.enabled=true` (and override the image if
-# the published name differs from the convention below).
+# nginx-served React/Vite bundle. Set `web.enabled=true` to deploy.
 #
-# Runtime config (apiUrl, OIDC client) is passed as env vars; the image is
-# expected to render `config.json` from these at container startup. See
-# docker/.env.example in the project for the naming convention.
+# Runtime config (oidc, apiUrl) is rendered into config.json at container
+# startup. The /api path inside the SPA's nginx is reverse-proxied to the
+# in-cluster API service via ${API_BACKEND}; that env var is auto-set to the
+# chart's api Service unless `apiBackend` overrides it below.
 web:
   enabled: false
   replicaCount: 1
@@ -254,9 +253,14 @@ web:
     type: ClusterIP
     port: 8080
   containerPort: 8080
-  # Path the SPA uses to reach the API. Relative paths assume the same
-  # ingress also routes that prefix to the api Service.
+  # SPA's runtime API URL (baked into config.json, used by the JS client).
+  # Relative path means same-origin — works when web's ingress also routes
+  # /api to the API service (via the embedded nginx proxy_pass below).
   apiUrl: /api
+  # Override the upstream that the SPA's embedded nginx /api proxy points at.
+  # Defaults to the in-cluster api Service URL. Set to e.g. http://api-other:8080
+  # only if you are intentionally fronting a different API.
+  apiBackend: ""
   oidc:
     clientId: ""
     redirectUri: ""
@@ -268,8 +272,9 @@ web:
     limits:
       cpu: 500m
       memory: 256Mi
-  # HTTP path used for liveness/readiness probes. Empty disables probes.
-  healthPath: /
+  # HTTP path used for startup/liveness/readiness probes. Empty disables probes.
+  # The image's nginx.conf serves a 200 "ok" at /healthz.
+  healthPath: /healthz
   env: []
   ingress:
     enabled: false

--- a/web/docker-entrypoint.sh
+++ b/web/docker-entrypoint.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
+# Generates /usr/share/nginx/html/config/config.json from environment variables.
+# Installed at /docker-entrypoint.d/30-generate-config-json.sh in the image; the
+# nginx base image runs every executable in /docker-entrypoint.d/ before launching
+# nginx, so we only have to write the file here, not start the server.
 set -e
 
-# Generate runtime configuration from environment variables
-# Frontend fetches /config/config.json, so we need to create that path
 mkdir -p /usr/share/nginx/html/config
 cat > /usr/share/nginx/html/config/config.json <<EOF
 {
@@ -13,8 +15,5 @@ cat > /usr/share/nginx/html/config/config.json <<EOF
 }
 EOF
 
-echo "✓ Generated runtime configuration:"
+echo "[entrypoint] generated /usr/share/nginx/html/config/config.json"
 cat /usr/share/nginx/html/config/config.json
-
-# Start nginx
-exec "$@"

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;
@@ -8,9 +8,11 @@ server {
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
-    # API proxy
+    # API proxy. ${API_BACKEND} is substituted at startup by nginx's templates feature.
+    # Defaults to http://api:8080 (matches docker-compose service name); override in
+    # k8s with the in-cluster API service URL, e.g. http://relate-mail-api:8080.
     location /api {
-        proxy_pass http://api:8080;
+        proxy_pass ${API_BACKEND};
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -19,6 +21,13 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_cache_bypass $http_upgrade;
+    }
+
+    # Health endpoint for k8s probes (returns the literal string "ok" with 200).
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 'ok';
     }
 
     # SPA fallback


### PR DESCRIPTION
## Summary

Two related changes the chart needs to be useful in k3s:

**1. Publish a separate `relate-mail-web` image.**
- New `web` stage in `api/Dockerfile` based on `nginxinc/nginx-unprivileged:1.27-alpine` (UID 101, port 8080 — no privileged-port handling needed).
- Reuses the existing `node-build` stage's `web/dist` output, plus `web/nginx.conf` (now templated) and `web/docker-entrypoint.sh` (now installed at `/docker-entrypoint.d/`).
- nginx.conf parameterizes the `/api` upstream as `${API_BACKEND}` and adds a `/healthz` endpoint. Defaults `API_BACKEND` to `http://api:8080` for docker-compose.
- Added `web` to the matrix in both `ci.yml` (PR validation) and `docker-publish.yml` (GHCR publish + Trivy scan).

**2. Add k3s-friendly probes across the chart.**
- `startupProbe` on `api / smtp / pop3 / imap` (5s period × 30 failures = 150s grace for .NET cold starts) so a slow first start can't fall into a livenessProbe restart loop on a small node.
- `startupProbe` on `web` (2s × 15 = 30s — nginx starts fast).
- Removed the now-redundant `initialDelaySeconds` on readiness/liveness; startupProbe gates them.
- `web.healthPath` default flipped from `/` to `/healthz` (the new endpoint in nginx.conf — doesn't depend on rendering index.html).
- Chart auto-wires `web`'s `API_BACKEND` env var to the in-cluster api Service URL, so a single ingress pointing at the web pod serves the SPA at `/` and forwards `/api` to the API without needing a second ingress rule. Overridable via `web.apiBackend`.

## Test plan
- [ ] `Docker Build Validation (web, web)` job passes on this PR
- [ ] After merge, `Build and Publish Docker Images` produces `ghcr.io/four-robots/relate-mail-web:main`
- [ ] `helm template demo helm/relate-mail --set postgresql.auth.password=devpass --set web.enabled=true` renders the web Deployment with `API_BACKEND=http://demo-relate-mail-api:8080` and startup/readiness/liveness probes on `/healthz`
- [ ] `helm template ... --set web.apiBackend=http://api-other:9000` overrides as expected
- [ ] Pulling and running the web image locally with `OIDC_AUTHORITY=…` etc. produces `/usr/share/nginx/html/config/config.json` with the expected fields
- [ ] On a k3s cluster with this chart, `kubectl describe pod` shows all three probe types green for every component

🤖 Generated with [Claude Code](https://claude.com/claude-code)