### PR TITLE
feat(helm,api): add EF Core migration Job to chart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,6 +452,8 @@ jobs:
             target: imap
           - name: web
             target: web
+          - name: migrations
+            target: migrations
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,6 +51,10 @@ jobs:
             context: .
             dockerfile: ./api/Dockerfile
             target: web
+          - name: migrations
+            context: .
+            dockerfile: ./api/Dockerfile
+            target: migrations
 
     steps:
       - name: Checkout repository
@@ -130,3 +134,4 @@ jobs:
           echo "- ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-pop3" >> $GITHUB_STEP_SUMMARY
           echo "- ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-imap" >> $GITHUB_STEP_SUMMARY
           echo "- ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-web" >> $GITHUB_STEP_SUMMARY
+          echo "- ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-migrations" >> $GITHUB_STEP_SUMMARY

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -44,6 +44,23 @@ RUN dotnet publish src/Relate.Smtp.SmtpHost/Relate.Smtp.SmtpHost.csproj -c Relea
 RUN dotnet publish src/Relate.Smtp.Pop3Host/Relate.Smtp.Pop3Host.csproj -c Release -o /app/pop3
 RUN dotnet publish src/Relate.Smtp.ImapHost/Relate.Smtp.ImapHost.csproj -c Release -o /app/imap
 
+# Build a self-contained EF Core migrations bundle. The bundle is a single
+# executable that applies pending migrations against a target connection
+# string passed via --connection, with no SDK or EF tools required at runtime.
+ARG TARGETARCH
+RUN dotnet tool install -g dotnet-ef --version 10.* \
+    && case "$TARGETARCH" in \
+        amd64) RID=linux-musl-x64 ;; \
+        arm64) RID=linux-musl-arm64 ;; \
+        *) echo "Unsupported TARGETARCH: $TARGETARCH" && exit 1 ;; \
+       esac \
+    && /root/.dotnet/tools/dotnet-ef migrations bundle \
+        --project src/Relate.Smtp.Infrastructure \
+        --startup-project src/Relate.Smtp.Api \
+        --self-contained \
+        -r "$RID" \
+        -o /app/migrations/efbundle
+
 # API runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine@sha256:8c7671a6f0f984d0c102ee70d61e8010857de032b320561dea97cc5781aea5f8 AS api
 WORKDIR /app
@@ -119,6 +136,24 @@ LABEL org.opencontainers.image.source="https://github.com/four-robots/relate-mai
 EXPOSE 143 993 8083
 ENV HealthCheck__Url=http://+:8083
 ENTRYPOINT ["dotnet", "Relate.Smtp.ImapHost.dll"]
+
+# EF Core migrations runtime image. Tiny image containing just the self-contained
+# migration bundle. Used by the chart's pre-install/pre-upgrade Job to bring the
+# database schema up to date before the API/protocol pods start.
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-alpine@sha256:4f08c162590324de60f31937f5b5fa9f2b5eddaa4f0aaec3c872f855bf16c36c AS migrations
+WORKDIR /app
+
+COPY --from=build /app/migrations/efbundle ./efbundle
+
+USER app
+
+# OCI Labels
+LABEL org.opencontainers.image.title="Relate Mail Migrations"
+LABEL org.opencontainers.image.description="EF Core migration bundle for the Relate Mail database schema"
+LABEL org.opencontainers.image.vendor="Relate Mail"
+LABEL org.opencontainers.image.source="https://github.com/four-robots/relate-mail"
+
+ENTRYPOINT ["./efbundle"]
 
 # Web (SPA) runtime image — separate from the API image so it can roll independently.
 # nginxinc/nginx-unprivileged runs as UID 101 and listens on 8080 by default, so no

--- a/helm/relate-mail/README.md
+++ b/helm/relate-mail/README.md
@@ -27,6 +27,7 @@ SMTP/POP3/IMAP ports can be exposed via separate `LoadBalancer` Services
 | pop3       | Deployment   | LoadBalancer         | 110, 995                                |
 | imap       | Deployment   | LoadBalancer         | 143, 993                                |
 | web        | Deployment   | ClusterIP            | 8080 (HTTP, disabled by default)        |
+| migrations | Job (hook)   | —                    | runs pre-install / pre-upgrade          |
 | postgresql | StatefulSet  | Headless ClusterIP   | 5432                                    |
 
 The SMTP, POP3, and IMAP hosts each expose an internal HTTP health endpoint
@@ -60,6 +61,25 @@ database:
   existingSecret: relate-mail-db
   existingSecretKey: connectionString
 ```
+
+### Schema migrations
+
+Schema migrations are applied by a Helm `pre-install` / `pre-upgrade` Job
+that runs the `relate-mail-migrations` image — a self-contained EF Core
+migration bundle. The Job runs before any other resource is installed or
+upgraded so the schema is current before the api/protocol pods start
+querying it. The bundle is idempotent and exits 0 with no work when the
+schema is already up to date.
+
+```yaml
+migrations:
+  enabled: true       # set false to skip schema migration on install/upgrade
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 300
+```
+
+If you manage migrations out-of-band (e.g. via a CD pipeline before
+`helm upgrade`), set `migrations.enabled: false`.
 
 ## Authentication
 

--- a/helm/relate-mail/templates/migration-job.yaml
+++ b/helm/relate-mail/templates/migration-job.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.migrations.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "relate-mail.componentFullname" (list . "migrations") }}
+  labels:
+    {{- include "relate-mail.componentLabels" (list . "migrations") | nindent 4 }}
+  annotations:
+    # Run before any other resource is installed/upgraded so the schema is
+    # current before api/smtp/pop3/imap pods start querying it.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.migrations.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.migrations.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "relate-mail.componentSelectorLabels" (list . "migrations") | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "relate-mail.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: migrations
+          image: {{ include "relate-mail.image" (dict "top" . "component" "migrations" "config" .Values.migrations) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          # The migration bundle accepts --connection at runtime. Kubernetes
+          # interpolates $(CONN) from env, so the connection string never lands
+          # in process listings as a literal — it's read from the secret.
+          args:
+            - --connection
+            - $(CONN)
+          env:
+            - name: CONN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "relate-mail.dbSecretName" . }}
+                  key: {{ include "relate-mail.dbSecretKey" . }}
+          resources:
+            {{- toYaml .Values.migrations.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/relate-mail/values.yaml
+++ b/helm/relate-mail/values.yaml
@@ -123,6 +123,28 @@ outbound:
   queuePollingIntervalSeconds: 15
   smtpTimeoutSeconds: 30
 
+# EF Core schema migrations.
+# Runs as a Helm pre-install/pre-upgrade Job that applies pending migrations
+# against the target database before the API/protocol pods start. The image
+# is a self-contained EF Core migration bundle — no SDK or EF tools required
+# at runtime, and idempotent (safe to re-run).
+migrations:
+  enabled: true
+  image:
+    repository: ""             # falls back to {{ image.registry }}/{{ image.repository }}-migrations
+    tag: ""
+  # Helm will retry the Job up to backoffLimit times before failing the release.
+  backoffLimit: 3
+  # Keep finished Jobs around briefly so logs are inspectable, then GC.
+  ttlSecondsAfterFinished: 300
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
 # REST API workload.
 api:
   enabled: true


### PR DESCRIPTION
## Summary

Pods previously CrashLooped on first install with `Npgsql.PostgresException 42P01: relation "OutboundEmails" does not exist` because schema migrations only run in the Development environment. The chart shipped no migration tooling, forcing deployers to use `skipAwait` workarounds or run migrations manually.

This PR adds a Helm `pre-install` / `pre-upgrade` Job that applies migrations before any other resource is installed/upgraded.

## Approach

**Option B from the discussion**: a separate, small migration image. Specifically using EF Core migration bundles — a self-contained executable that applies migrations with no SDK or EF tools required at runtime (~tens of MB rather than the ~1GB SDK image).

### Changes

- **`api/Dockerfile`** — new `migrations` target:
  - In the build stage, install `dotnet-ef` and run `dotnet ef migrations bundle --self-contained -r linux-musl-{x64,arm64}` (RID picked via `TARGETARCH` for buildx multiarch)
  - Runtime stage uses `mcr.microsoft.com/dotnet/runtime-deps:10.0-alpine` with the bundle as ENTRYPOINT
- **`helm/relate-mail/templates/migration-job.yaml`** — new Job template:
  - Annotations: `helm.sh/hook: pre-install,pre-upgrade`, `helm.sh/hook-weight: -5`, `helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded`
  - Reads connection string from existing db Secret via env var, passes to bundle as `--connection $(CONN)` (Kubernetes substitutes at start time, secret never lands in process listings as literal)
  - Configurable `backoffLimit` (3) and `ttlSecondsAfterFinished` (300)
- **`helm/relate-mail/values.yaml`** — `migrations` config block (enabled by default)
- **`.github/workflows/docker-publish.yml`** — adds `migrations` to matrix, publishes `ghcr.io/four-robots/relate-mail-migrations`
- **`.github/workflows/ci.yml`** — adds `migrations` to docker-validate matrix
- **`helm/relate-mail/README.md`** — documents the schema migration behavior

After this lands and is vendored downstream, `skipAwait: true` can be removed from the pulumi `relate-mail` app.

## Test plan

- [x] `helm lint ./helm/relate-mail --set postgresql.auth.password=test` passes
- [x] `helm template` renders the Job manifest with correct hook annotations
- [x] EF migration bundle generates locally (`dotnet ef migrations bundle --self-contained -r linux-musl-x64`)
- [ ] CI docker-validate builds the migrations target on PR
- [ ] First install on a fresh cluster: Job runs, succeeds, then api/smtp/pop3/imap pods become Ready
- [ ] Upgrade on existing cluster: Job runs, no-op when schema is current

🤖 Generated with [Claude Code](https://claude.com/claude-code)