### PR TITLE
fix(migrations): default extract dir to /tmp and expose extraEnv

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -147,6 +147,13 @@ COPY --from=build /app/migrations/efbundle ./efbundle
 
 USER app
 
+# Self-contained single-file binaries extract their bundled assemblies to a
+# scratch dir on first run. The default is $HOME/.net which fails when the
+# pod's root filesystem is read-only (or when HOME isn't writable). /tmp is
+# always writable, so point the extractor there. See:
+# https://learn.microsoft.com/dotnet/core/deploying/single-file/overview#extract-to-different-location
+ENV DOTNET_BUNDLE_EXTRACT_BASE_DIR=/tmp/.net
+
 # OCI Labels
 LABEL org.opencontainers.image.title="Relate Mail Migrations"
 LABEL org.opencontainers.image.description="EF Core migration bundle for the Relate Mail database schema"

--- a/helm/relate-mail/templates/migration-job.yaml
+++ b/helm/relate-mail/templates/migration-job.yaml
@@ -52,6 +52,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "relate-mail.dbSecretName" . }}
                   key: {{ include "relate-mail.dbSecretKey" . }}
+            {{- with .Values.migrations.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.migrations.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/helm/relate-mail/values.yaml
+++ b/helm/relate-mail/values.yaml
@@ -137,6 +137,14 @@ migrations:
   backoffLimit: 3
   # Keep finished Jobs around briefly so logs are inspectable, then GC.
   ttlSecondsAfterFinished: 300
+  # Extra environment variables for the migration container. Useful when the
+  # bundle needs runtime-only config that isn't supplied by the chart, e.g.
+  # forcing a write path off a read-only root filesystem.
+  # Example:
+  #   extraEnv:
+  #     - name: DOTNET_BUNDLE_EXTRACT_BASE_DIR
+  #       value: /tmp/.net
+  extraEnv: []
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
## Summary

Follow-ups to #248 for consumers running the migration Job under `readOnlyRootFilesystem: true` (or any pod where `\$HOME` isn't writable):

1. **Set `DOTNET_BUNDLE_EXTRACT_BASE_DIR=/tmp/.net` in the migrations image.** Self-contained single-file binaries extract their bundled assemblies to a scratch directory on first run. The default is `\$HOME/.net`, which fails on read-only roots or when `HOME` isn't writable. `/tmp` is reliably writable across pod security contexts. Setting this in the Dockerfile makes the image safe-by-default — consumers don't have to know about it.
2. **Expose `migrations.extraEnv` on the chart** so deployers can inject their own env vars (tracing, alternate extract paths, custom logging, etc.) without forking the chart.

## Test plan

- [x] `helm lint` passes
- [x] `helm template` renders `extraEnv` entries correctly when populated
- [x] `helm template` still renders cleanly with default empty `extraEnv: []`
- [ ] Migration Job runs successfully under `readOnlyRootFilesystem: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)