### PR TITLE
fix(api,helm): unblock pods on k8s — host filter + auth salt

### DIFF
--- a/api/src/Relate.Smtp.Api/appsettings.json
+++ b/api/src/Relate.Smtp.Api/appsettings.json
@@ -68,5 +68,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "localhost"
+  "AllowedHosts": "*"
 }

--- a/helm/relate-mail/templates/_helpers.tpl
+++ b/helm/relate-mail/templates/_helpers.tpl
@@ -153,6 +153,50 @@ internalApiKey
 {{- end -}}
 
 {{/*
+Security/authentication-salt secret name + key, mirroring the internal pattern.
+*/}}
+{{- define "relate-mail.securitySecretName" -}}
+{{- if .Values.security.existingSecret -}}
+{{- .Values.security.existingSecret -}}
+{{- else -}}
+{{- printf "%s-security" (include "relate-mail.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "relate-mail.securitySecretKey" -}}
+{{- if .Values.security.existingSecret -}}
+{{- .Values.security.existingSecretKey | default "authenticationSalt" -}}
+{{- else -}}
+authenticationSalt
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the authentication salt. Priority:
+  1) explicit security.authenticationSalt
+  2) existing chart-managed Secret (preserves the salt across upgrades)
+  3) freshly-generated random 32-char alphanum
+A regenerated salt only resets rate-limit counters; it doesn't invalidate user
+auth or sessions, so an occasional rotation (e.g. on a Pulumi-style fresh
+template render) is harmless.
+*/}}
+{{- define "relate-mail.authenticationSalt" -}}
+{{- if .Values.security.authenticationSalt -}}
+{{- .Values.security.authenticationSalt -}}
+{{- else if .Values.security.existingSecret -}}
+{{- /* Caller-supplied secret; we don't read it, the env var binds at runtime. */ -}}
+{{- else -}}
+{{- $secretName := printf "%s-security" (include "relate-mail.fullname" .) -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- if and $existing $existing.data (index $existing.data "authenticationSalt") -}}
+{{- index $existing.data "authenticationSalt" | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 32 -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Outbound relay password secret name/key.
 */}}
 {{- define "relate-mail.outboundSecretName" -}}

--- a/helm/relate-mail/templates/api-deployment.yaml
+++ b/helm/relate-mail/templates/api-deployment.yaml
@@ -50,6 +50,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "relate-mail.dbSecretName" . }}
                   key: {{ include "relate-mail.dbSecretKey" . }}
+            - name: Security__AuthenticationSalt
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "relate-mail.securitySecretName" . }}
+                  key: {{ include "relate-mail.securitySecretKey" . }}
             {{- if .Values.oidc.authority }}
             - name: Oidc__Authority
               value: {{ .Values.oidc.authority | quote }}

--- a/helm/relate-mail/templates/imap-deployment.yaml
+++ b/helm/relate-mail/templates/imap-deployment.yaml
@@ -54,6 +54,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "relate-mail.dbSecretName" . }}
                   key: {{ include "relate-mail.dbSecretKey" . }}
+            - name: Security__AuthenticationSalt
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "relate-mail.securitySecretName" . }}
+                  key: {{ include "relate-mail.securitySecretKey" . }}
             - name: Imap__ServerName
               value: {{ .Values.imap.serverName | quote }}
             - name: Imap__Port

--- a/helm/relate-mail/templates/pop3-deployment.yaml
+++ b/helm/relate-mail/templates/pop3-deployment.yaml
@@ -54,6 +54,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "relate-mail.dbSecretName" . }}
                   key: {{ include "relate-mail.dbSecretKey" . }}
+            - name: Security__AuthenticationSalt
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "relate-mail.securitySecretName" . }}
+                  key: {{ include "relate-mail.securitySecretKey" . }}
             - name: Pop3__ServerName
               value: {{ .Values.pop3.serverName | quote }}
             - name: Pop3__Port

--- a/helm/relate-mail/templates/secret-security.yaml
+++ b/helm/relate-mail/templates/secret-security.yaml
@@ -1,0 +1,17 @@
+{{- if not .Values.security.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-security" (include "relate-mail.fullname" .) }}
+  labels:
+    {{- include "relate-mail.labels" . | nindent 4 }}
+  annotations:
+    # Don't let helm rotate the salt on every upgrade — if the secret already
+    # exists in the cluster, leave its data alone. Combined with the lookup
+    # in `relate-mail.authenticationSalt`, this keeps rate-limit state stable
+    # across helm upgrades while still seeding a value on first install.
+    "helm.sh/resource-policy": keep
+type: Opaque
+stringData:
+  authenticationSalt: {{ include "relate-mail.authenticationSalt" . | quote }}
+{{- end }}

--- a/helm/relate-mail/templates/smtp-deployment.yaml
+++ b/helm/relate-mail/templates/smtp-deployment.yaml
@@ -59,6 +59,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "relate-mail.dbSecretName" . }}
                   key: {{ include "relate-mail.dbSecretKey" . }}
+            - name: Security__AuthenticationSalt
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "relate-mail.securitySecretName" . }}
+                  key: {{ include "relate-mail.securitySecretKey" . }}
             - name: Smtp__ServerName
               value: {{ .Values.smtp.serverName | quote }}
             - name: Smtp__Port

--- a/helm/relate-mail/values.yaml
+++ b/helm/relate-mail/values.yaml
@@ -91,6 +91,19 @@ internal:
   existingSecret: ""
   existingSecretKey: internalApiKey
 
+# Security settings shared across all hosts.
+# `authenticationSalt` is the HMAC key used by the auth rate limiter to hash
+# usernames + client IPs for tracking failed-login attempts. The .NET API
+# *requires* this in production and refuses to start without it.
+#
+# Provide it inline, via an existing Secret, or leave both empty — the chart
+# will lookup an existing chart-managed Secret across upgrades, and only
+# generate a fresh random salt on the first install.
+security:
+  authenticationSalt: ""
+  existingSecret: ""
+  existingSecretKey: authenticationSalt
+
 # CORS for the API (comma-separated origins).
 cors:
   allowedOrigins: ""


### PR DESCRIPTION
## Summary

Two issues observed running the chart on a real k3s cluster — both block pods from becoming Ready.

### 1. `/healthz` returns 400 to all probes and ingress requests

The API's `appsettings.json` shipped with `AllowedHosts: "localhost"`, which makes ASP.NET Core's `HostFiltering` middleware reject any request whose Host header isn't literally `localhost`. That includes:

- kube-probes (`Host: 10.42.0.213:8080`) → 400 → Ready=false → CrashLoopBackOff
- Ingress requests (`Host: relate.ottercoders.dev`) → 400

Changed the default to `"*"` to match the ASP.NET Core project template. Host header filtering isn't a meaningful security boundary in a k8s deployment — the ingress / network policy handles that.

### 2. SMTP/POP3/IMAP CrashLoopBackOff: missing `Security:AuthenticationSalt`

```
System.InvalidOperationException: Security:AuthenticationSalt must be configured in production.
Generate with: openssl rand -base64 32
   at Relate.Smtp.Infrastructure.Services.AuthenticationRateLimiter..ctor(...)
```

The auth rate limiter HMACs usernames+IPs with this salt. The chart didn't expose it.

Add a `security` section to `values.yaml` mirroring the existing `internal` / `outbound` patterns:

```yaml
security:
  authenticationSalt: ""        # provide inline
  existingSecret: ""            # ...or via existing Secret
  existingSecretKey: authenticationSalt
```

If neither is set, the chart auto-generates a 32-char alphanum salt and stores it in `<release>-security`. The Secret is annotated `helm.sh/resource-policy: keep`, and the helper uses `lookup` to read back the existing salt on upgrade — so the value is stable across upgrades on the same cluster. A regenerated salt only resets rate-limit counters, not user sessions, so occasional rotation (e.g. fresh `helm template` from a CD tool that doesn't preserve cluster state) is safe.

`Security__AuthenticationSalt` is now injected into all four deployments (api, smtp, pop3, imap).

## Known follow-ups (separate PR)

Visible in the API logs but not blocking pod readiness:
- DataProtection keys are ephemeral (`EphemeralXmlRepository`). Fine for single-replica; with N>1 replicas, anti-forgery and cookie protection won't share keys. Needs a chart-managed PVC + `services.AddDataProtection().PersistKeysToFileSystem(...)` wiring.
- Npgsql logs `Error loading shared library libgssapi_krb5.so.2`. Cosmetic — Npgsql probes for Kerberos before falling back to password auth. Fixed by adding `krb5-libs` to the alpine runtime images, or by including `Integrated Security=false` in the connection string.

## Test plan

- [x] `helm lint` passes
- [x] `helm template` renders the security Secret + env var injection in all four deployments
- [ ] Apply to k3s: api/smtp/pop3/imap pods reach Ready, `/healthz` returns 200 to kube-probe
- [ ] `helm upgrade`: existing salt preserved, no pod restart from salt change

🤖 Generated with [Claude Code](https://claude.com/claude-code)