### PR TITLE
fix(web): handle missing OIDC context in dev mode

### DIFF
--- a/web/src/auth/useAuth.ts
+++ b/web/src/auth/useAuth.ts
@@ -1,0 +1,62 @@
+import { useAuth as useOidcAuth, type AuthContextProps } from 'react-oidc-context'
+
+/**
+ * Wraps `react-oidc-context`'s `useAuth` so the rest of the app can call it
+ * unconditionally. When `oidc.authority` is empty in runtime config, the
+ * `<AuthProvider />` in `auth/AuthProvider.tsx` renders its children without
+ * the OIDC context — so the upstream `useAuth()` returns `undefined`, and any
+ * downstream `auth.isAuthenticated` access blows up with TypeError.
+ *
+ * This shim returns a sensible "auth bypassed" stub in that case, matching the
+ * intent of the AuthProvider's dev-mode branch: the user is treated as logged
+ * in, and the auth-related actions are no-ops.
+ */
+export function useAuth(): AuthContextProps {
+  const auth = useOidcAuth()
+  if (auth) return auth
+  return DEV_MODE_STUB
+}
+
+const DEV_MODE_STUB: AuthContextProps = {
+  isAuthenticated: true,
+  isLoading: false,
+  activeNavigator: undefined,
+  error: undefined,
+  user: {
+    profile: {
+      sub: 'dev-user',
+      email: 'dev@localhost',
+      name: 'Dev User',
+      preferred_username: 'dev',
+      iss: 'dev',
+      aud: 'dev',
+      exp: Number.MAX_SAFE_INTEGER,
+      iat: 0,
+    },
+    access_token: '',
+    token_type: 'Bearer',
+    expires_at: Number.MAX_SAFE_INTEGER,
+    scope: 'openid profile email',
+    state: undefined,
+    session_state: null,
+    expires_in: Number.MAX_SAFE_INTEGER,
+    expired: false,
+    scopes: ['openid', 'profile', 'email'],
+    toStorageString: () => '',
+  } as unknown as AuthContextProps['user'],
+  settings: {} as AuthContextProps['settings'],
+  events: {} as AuthContextProps['events'],
+  signinRedirect: async () => {},
+  signinResourceOwnerCredentials: async () => undefined as never,
+  signinPopup: async () => undefined as never,
+  signinSilent: async () => null,
+  signoutRedirect: async () => {},
+  signoutPopup: async () => {},
+  signoutSilent: async () => {},
+  removeUser: async () => {},
+  querySessionStatus: async () => null,
+  revokeTokens: async () => {},
+  startSilentRenew: () => {},
+  stopSilentRenew: () => {},
+  clearStaleState: async () => {},
+}

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { createRootRoute, Link, Outlet, useLocation } from '@tanstack/react-router'
-import { useAuth } from 'react-oidc-context'
+import { useAuth } from '@/auth/useAuth'
 import { Mail, User, LogOut, Menu, X, PenSquare } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useTheme } from '@/hooks/use-theme'

--- a/web/src/routes/callback.tsx
+++ b/web/src/routes/callback.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useAuth } from 'react-oidc-context'
+import { useAuth } from '@/auth/useAuth'
 import { useEffect, useCallback, useMemo } from 'react'
 
 export const Route = createFileRoute('/callback')({

--- a/web/src/routes/compose.tsx
+++ b/web/src/routes/compose.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { createFileRoute, useNavigate, useSearch } from '@tanstack/react-router'
-import { useAuth } from 'react-oidc-context'
+import { useAuth } from '@/auth/useAuth'
 import { getConfig } from '@/config'
 import { useProfile, useSendEmail, useReplyToEmail, useForwardEmail, useEmail } from '@/api/hooks'
 import { Button } from '@/components/ui/button'

--- a/web/src/routes/drafts.tsx
+++ b/web/src/routes/drafts.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useState, useEffect } from 'react'
-import { useAuth } from 'react-oidc-context'
+import { useAuth } from '@/auth/useAuth'
 import { getConfig } from '@/config'
 import { useDrafts, useDeleteDraft, useSendDraft } from '@/api/hooks'
 import { Button } from '@/components/ui/button'

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useAuth } from 'react-oidc-context'
+import { useAuth } from '@/auth/useAuth'
 import { getConfig } from '@/config'
 import { useQueryClient } from '@tanstack/react-query'
 import { useEmails, useEmail, useMarkEmailRead, useDeleteEmail, useSearchEmails, type EmailSearchFilters } from '@/api/hooks'

--- a/web/src/routes/login.tsx
+++ b/web/src/routes/login.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useAuth } from 'react-oidc-context'
+import { useAuth } from '@/auth/useAuth'
 import { useEffect } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'

--- a/web/src/routes/outbox.tsx
+++ b/web/src/routes/outbox.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useState, useEffect } from 'react'
-import { useAuth } from 'react-oidc-context'
+import { useAuth } from '@/auth/useAuth'
 import { getConfig } from '@/config'
 import { useOutbox } from '@/api/hooks'
 import { Badge } from '@/components/ui/badge'

--- a/web/src/routes/preferences.tsx
+++ b/web/src/routes/preferences.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useAuth } from 'react-oidc-context'
+import { useAuth } from '@/auth/useAuth'
 import { getConfig } from '@/config'
 import { usePreferences, useUpdatePreferences } from '@/api/hooks'
 import { usePushNotifications } from '@/hooks/use-push-notifications'

--- a/web/src/routes/profile.tsx
+++ b/web/src/routes/profile.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useAuth } from 'react-oidc-context'
+import { useAuth } from '@/auth/useAuth'
 import { getConfig } from '@/config'
 import { useProfile, useUpdateProfile, useAddEmailAddress, useRemoveEmailAddress, useSendVerification, useVerifyEmailAddress } from '@/api/hooks'
 import { Button } from '@/components/ui/button'

--- a/web/src/routes/sent.tsx
+++ b/web/src/routes/sent.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useState, useEffect } from 'react'
-import { useAuth } from 'react-oidc-context'
+import { useAuth } from '@/auth/useAuth'
 import { getConfig } from '@/config'
 import { useSentEmails, useSentFromAddresses } from '../api/hooks'
 import { EmailList } from '../components/mail/email-list'

--- a/web/src/routes/smtp-settings.tsx
+++ b/web/src/routes/smtp-settings.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useAuth } from 'react-oidc-context'
+import { useAuth } from '@/auth/useAuth'
 import { getConfig } from '@/config'
 import { useSmtpCredentials, useCreateSmtpApiKey, useRevokeSmtpApiKey } from '@/api/hooks'
 import { Button } from '@/components/ui/button'


### PR DESCRIPTION
## Summary

Production SPA crashes on every page load with:

\`\`\`
TypeError: can't access property "isAuthenticated", t is undefined
\`\`\`

when the chart is deployed without OIDC configured (`oidc.authority: ""`). \`AuthProvider\` already has a "dev mode" branch that renders children without wrapping them in the OIDC context — but every route still calls \`useAuth()\` from \`react-oidc-context\` and unconditionally derefs \`auth.isAuthenticated\`, so the whole tree dies on first render.

## Fix

Add `web/src/auth/useAuth.ts` — a shim that returns the upstream `useAuth()` when the OIDC provider is mounted, and a dev-mode stub when it isn't:

- `isAuthenticated: true` (matches AuthProvider's "no auth" intent — render the app)
- `isLoading: false`, `error: undefined`
- placeholder dev user with `email`, `sub`, etc.
- no-op `signinRedirect` / `signoutRedirect` / etc.

Switch all 11 route file imports from `react-oidc-context` to the local shim. `AuthProvider.tsx` is the only file still importing from the upstream package.

## Why a stub instead of always wrapping in OIDC

The OIDC provider needs an `authority` URL to do anything useful. Stubbing the hook keeps the dev-mode path explicit and avoids feeding `react-oidc-context` a bogus authority just to satisfy types.

## Test plan

- [x] `npm run build` passes (tsc + vite)
- [ ] Production deploy with `oidc.authority: ""` no longer crashes; SPA renders
- [ ] OIDC-enabled deploy still works (provider mounted → real `useAuth()` returned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)